### PR TITLE
Always resize canvas on change tile grid in tile editor.

### DIFF
--- a/wwwroot/modules/ui/tileEditor.js
+++ b/wwwroot/modules/ui/tileEditor.js
@@ -146,6 +146,7 @@ export default class TileEditor extends ComponentBase {
         // Changing tile grid
         const tileGrid = state?.tileGrid;
         if (tileGrid instanceof TileGridProvider || tileGrid === null) {
+            resizeCanvas(this.#tbCanvas);
             this.#canvasManager.invalidateImage();
             this.#tileGrid = tileGrid;
             dirty = true;


### PR DESCRIPTION
Solve issue when creating a new project when no project already exists the tile editor preview image is confined to a default small size at the top-left of the viewport window.