### PR TITLE
Improve usibility when changing projects or tile maps

### DIFF
--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -1558,10 +1558,12 @@ function handleImageImportModalOnConfirm(args) {
     setCommonTileToolbarStates({
         tileWidth: getTileSet().tileWidth
     });
+    const focusedTile = (Math.floor(getTileGrid().rowCount / 2) * getTileGrid().columnCount) + (Math.floor(getTileGrid().columnCount) / 2);
     tileEditor.setState({
         paletteList: getTileEditorPaletteList(),
         tileGrid: getTileGrid(),
-        tileSet: getTileSet()
+        tileSet: getTileSet(),
+        focusedTile: focusedTile
     });
     projectToolbar.setState({
         projectTitle: getProject().title
@@ -2062,6 +2064,7 @@ function formatForProject() {
         showPixelGridChecked: getUIState().showPixelGrid,
         enabled: true
     });
+    const focusedTile = (Math.floor(getTileGrid().rowCount / 2) * getTileGrid().columnCount) + (Math.floor(getTileGrid().columnCount) / 2);
     tileEditor.setState({
         palette: palette,
         paletteList: getTileEditorPaletteList(),
@@ -2073,6 +2076,7 @@ function formatForProject() {
         cursorSize: instanceState.pencilSize,
         showTileGrid: getUIState().showTileGrid,
         showPixelGrid: getUIState().showPixelGrid,
+        focusedTile: focusedTile,
         enabled: true
     });
     tileContextToolbar.setState({
@@ -3938,6 +3942,12 @@ function selectTileSetOrMap(tileMapId) {
     state.saveToLocalStorage();
 
     refreshProjectUI();
+
+    // Focus the centre tile
+    const focusedTile = (Math.floor(getTileGrid().rowCount / 2) * getTileGrid().columnCount) + (Math.floor(getTileGrid().columnCount) / 2);
+    tileEditor.setState({
+        focusedTile: focusedTile
+    });
 }
 
 /**

--- a/wwwroot/modules/ui/tileEditor.js
+++ b/wwwroot/modules/ui/tileEditor.js
@@ -591,10 +591,8 @@ export default class TileEditor extends ComponentBase {
         const col = index % this.#tileSet.tileWidth;
         const row = Math.floor(index / this.#tileSet.tileWidth);
         const pxPerTile = this.#canvasManager.scale * 8;
-        const tileY = (row * pxPerTile) + (this.#canvasManager.scale / 2);
-        // const rect = this.#canvasContainer.getBoundingClientRect();
-        // this.#canvasContainer.scrollLeft = Math.max(tileX - (rect.width / 2), 0);
-        // this.#canvasContainer.scrollTop = Math.max(tileY - (rect.height / 2), 0);
+        this.#canvasManager.offsetX = col / pxPerTile;
+        this.#canvasManager.offsetY = row / pxPerTile;
     }
 
 


### PR DESCRIPTION
Calculate middle tile of the tile map or set, and centre on it when the project or tile map/set changes.