### PR TITLE
Project IDs of loaded JSON no longer overwrite existing ones

### DIFF
--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -3529,13 +3529,19 @@ function importProjectFromJson() {
     input.onchange = () => {
         if (input.files.length > 0) {
             // Load the project from the file
-            ProjectUtil.loadFromBlob(input.files[0]).then(project => {
+            ProjectUtil.loadFromBlob(input.files[0]).then((project) => {
                 addUndoState();
 
+                // If it doesn't exist, use the project ID
+                const preferredProjectId = project.id;
+                project.id = state.getProjectIdThatDoesntCollide(preferredProjectId);
+
+                // Store the project
                 state.setProject(project);
                 state.saveProjectToLocalStorage();
                 getProjectUIState().paletteIndex = 0;
 
+                // Display the project
                 displaySelectedProject();
                 projectDropdown.setState({ visible: false });
                 welcomeScreen.setState({ visible: false });

--- a/wwwroot/modules/util/projectUtil.js
+++ b/wwwroot/modules/util/projectUtil.js
@@ -1,6 +1,7 @@
 import Project from "../models/project.js";
 import ProjectJsonSerialiser from "../serialisers/projectJsonSerialiser.js";
 import FileUtil from "./fileUtil.js";
+import GeneralUtil from "./generalUtil.js";
 
 export default class ProjectUtil {
 
@@ -37,5 +38,13 @@ export default class ProjectUtil {
         return ProjectJsonSerialiser.deserialise(text);
     }
 
+    /**
+     * Generates a new project ID.
+     * @returns {string}
+     */
+    static generateProjectId() {
+        return GeneralUtil.generateRandomString(16);
+    }
+    
 
 }


### PR DESCRIPTION
- Add methods to generate a new project ID.
- When project is loaded from file, attempt to use project ID from file first, but otherwise generate a new project ID if it already exists.