### PR TITLE
Added "is sprite" tile map option, and some other things

### DIFF
--- a/wwwroot/modules/components/canvasManager.js
+++ b/wwwroot/modules/components/canvasManager.js
@@ -603,9 +603,10 @@ export default class CanvasManager {
      * Refreshes the entire tile image.
      */
     #refreshTileImage() {
-        const transColour = this.#referenceImages.filter(r => r.image !== null).length > 0 ? this.#transparencyIndex : -1;
+        // const transColour = this.#referenceImages.filter(r => r.image !== null).length > 0 ? this.#transparencyIndex : -1;
         this.#gridPatternCanvas = createGridPatternCanvas(this.scale);
-        this.#drawTileImage(this.#tileCanvas, transColour);
+        // this.#drawTileImage(this.#tileCanvas, transColour);
+        this.#drawTileImage(this.#tileCanvas, this.#transparencyIndex);
     }
 
     /**
@@ -673,8 +674,13 @@ export default class CanvasManager {
 
         context.imageSmoothingEnabled = false;
 
+        if (!tile || transparencyColour >= 0) {
+            // Draw in transparency pixel mesh when the tile doesn't exist
+            const originX = (tileGridCol * 8) * pxSize;
+            const originY = (tileGridRow * 8) * pxSize;
+            context.drawImage(this.#gridPatternCanvas, originX, originY);
+        }
         if (tile) {
-
             const tileCanvas = this.#tileImageManager.getTileImage(tile, palette, transparencyColour);
 
             // Tile exists 
@@ -698,10 +704,6 @@ export default class CanvasManager {
             }
         } else {
             this.#tileImageManager.clearByTile(tileInfo.tileId);
-            // Draw in pixel mesh when the tile doesn't exist
-            const originX = (tileGridCol * 8) * pxSize;
-            const originY = (tileGridRow * 8) * pxSize;
-            context.drawImage(this.#gridPatternCanvas, originX, originY);
         }
     }
 
@@ -1301,7 +1303,7 @@ function isInBounds(tileGrid, row, column) {
  * @returns {CanvasPattern}
  */
 function createGridPatternCanvas(scale) {
-    const gridColour1 = 'rgba(255,255,255,0.25)';
+    const gridColour1 = 'rgba(255,255,255,0.15)';
     const gridColour2 = 'rgba(0,0,0,0.25)';
     const gridSizePx = 2;
     const gridCanvas = document.createElement('canvas');

--- a/wwwroot/modules/components/canvasManager.js
+++ b/wwwroot/modules/components/canvasManager.js
@@ -9,6 +9,7 @@ import TileMap from "../models/tileMap.js";
 import TileMapFactory from "../factory/tileMapFactory.js";
 import PaintUtil from "../util/paintUtil.js";
 import TileImageManager from "./tileImageManager.js";
+import PaletteListFactory from "../factory/paletteListFactory.js";
 
 
 const highlightModes = {
@@ -185,6 +186,16 @@ export default class CanvasManager {
     }
 
     /**
+     * Gets or sets the locked palette slot index from 0 to 15, null for none.
+     */
+    get lockedPaletteSlotIndex() {
+        return this.#lockedPaletteSlotIndex;
+    }
+    set lockedPaletteSlotIndex(value) {
+        this.#lockedPaletteSlotIndex = value;
+    }
+
+    /**
      * Gets or sets the X offset of the tile grid image.
      */
     get offsetX() {
@@ -273,6 +284,8 @@ export default class CanvasManager {
     #tileSet = null;
     /** @type {PaletteList} */
     #paletteList = null;
+    /** @type {PaletteList} */
+    #renderPaletteList = null;
     /** @type {number} */
     #scale = 10;
     /** @type {number} */
@@ -283,6 +296,8 @@ export default class CanvasManager {
     #selectedRegion = null;
     #cursorSize = 1;
     #transparencyIndex = 15;
+    /** @type {number?} */
+    #lockedPaletteSlotIndex = null;
     #drawTileGrid = false;
     #drawPixelGrid = false;
     /** @type {ReferenceImage[]} */
@@ -320,6 +335,7 @@ export default class CanvasManager {
     invalidateImage() {
         // Set redraw variables
         this.#needToDrawTileImage = true;
+        this.#renderPaletteList = null;
         this.#tilePreviewCanvas = null;
     }
 
@@ -603,9 +619,7 @@ export default class CanvasManager {
      * Refreshes the entire tile image.
      */
     #refreshTileImage() {
-        // const transColour = this.#referenceImages.filter(r => r.image !== null).length > 0 ? this.#transparencyIndex : -1;
         this.#gridPatternCanvas = createGridPatternCanvas(this.scale);
-        // this.#drawTileImage(this.#tileCanvas, transColour);
         this.#drawTileImage(this.#tileCanvas, this.#transparencyIndex);
     }
 
@@ -664,13 +678,15 @@ export default class CanvasManager {
      * @param {number} transparencyColour 
      */
     #drawTile(context, tileindex, transparencyColour) {
+        this.#buildRenderPaletteList();
+
         const pxSize = this.scale;
         const tileInfo = this.tileGrid.getTileInfoByIndex(tileindex);
         const tile = this.tileSet.getTileById(tileInfo.tileId);
         const tileWidth = Math.max(this.tileGrid.columnCount, 1);
         const tileGridCol = tileindex % tileWidth;
         const tileGridRow = (tileindex - tileGridCol) / tileWidth;
-        const palette = this.paletteList.getPalette(tileInfo.paletteIndex);
+        const palette = this.#renderPaletteList.getPalette(tileInfo.paletteIndex);
 
         context.imageSmoothingEnabled = false;
 
@@ -704,6 +720,27 @@ export default class CanvasManager {
             }
         } else {
             this.#tileImageManager.clearByTile(tileInfo.tileId);
+        }
+    }
+
+    #buildRenderPaletteList() {
+        if (this.#renderPaletteList !== null) return;
+        if (this.lockedPaletteSlotIndex !== null && this.lockedPaletteSlotIndex >= 0 && this.lockedPaletteSlotIndex < this.paletteList.getPalette(0).getColours().length) {
+            const list = PaletteListFactory.clone(this.paletteList);
+            const lockColour = this.paletteList.getPalette(0).getColour(this.lockedPaletteSlotIndex);
+            for (let i = 1; i < list.getPalettes().length; i++) {
+                const colour = list.getPalette(i).getColour(this.lockedPaletteSlotIndex);
+                colour.r = lockColour.r;
+                colour.g = lockColour.g;
+                colour.b = lockColour.b;
+            }
+            list.getPalettes().forEach((p) => {
+                p.paletteId = `${p.paletteId}[lock:${this.lockedPaletteSlotIndex}]`;
+                this.#tileImageManager.clearByPalette(p.paletteId);
+            });
+            this.#renderPaletteList = list;
+        } else {
+            this.#renderPaletteList = this.paletteList;
         }
     }
 

--- a/wwwroot/modules/factory/paletteListFactory.js
+++ b/wwwroot/modules/factory/paletteListFactory.js
@@ -1,5 +1,6 @@
 import PaletteList from "../models/paletteList.js";
 import Palette from "../models/palette.js";
+import PaletteFactory from "./paletteFactory.js";
 
 export default class PaletteListFactory {
 
@@ -10,6 +11,19 @@ export default class PaletteListFactory {
      */
      static create(palettes) {
         return new PaletteList(palettes);
+    }
+
+    /**
+     * Creates a deep clone of the given palette list.
+     * @param {PaletteList} paletteList - Palette list object to create a deep clone of.
+     * @returns {PaletteList}
+     */
+    static clone(paletteList) {
+        const result = new PaletteList();
+        paletteList.getPalettes().forEach((p) => {
+            result.addPalette(PaletteFactory.clone(p));
+        });
+        return result;
     }
 
 

--- a/wwwroot/modules/factory/tileMapFactory.js
+++ b/wwwroot/modules/factory/tileMapFactory.js
@@ -1,13 +1,13 @@
 import TileMap from "../models/tileMap.js";
-import TileMapList from "../models/tileMapList.js";
 import TileMapTile from "../models/tileMapTile.js";
-import TileSet from "../models/tileSet.js";
 import GeneralUtil from "../util/generalUtil.js";
-import TileUtil from "../util/tileUtil.js";
-import TileMapListFactory from "../factory/tileMapListFactory.js";
 import TileMapTileFactory from "../factory/tileMapTileFactory.js";
 import TileMapJsonSerialiser from "../serialisers/tileMapJsonSerialiser.js";
 
+
+/**
+ * Provides factory methods for constructing tile map objects.
+ */
 export default class TileMapFactory {
 
 
@@ -29,6 +29,7 @@ export default class TileMapFactory {
         result.title = (typeof args.title === 'string' && args.title.length > 0) ? args.title : 'Tile map';
         result.vramOffset = (typeof args.vramOffset === 'number') ? args.vramOffset : 0;
         result.optimise = (typeof args.optimise === 'boolean') ? args.optimise : true;
+        result.isSprite = (typeof args.isSprite === 'boolean') ? args.isSprite : true;
 
         if (Array.isArray(args.paletteSlots)) {
             args.paletteSlots.forEach((paletteId, index) => {
@@ -67,17 +68,19 @@ export default class TileMapFactory {
 
 }
 /**
+ * Arguments for creating a tile map.
  * @typedef TileMapFactoryCreateArgs
  * @type {object}
- * @property {string?} tileMapId
- * @property {string?} title
- * @property {number?} vramOffset
- * @property {number?} rows
- * @property {number?} columns
- * @property {boolean?} optimise
- * @property {string[]?} paletteSlots
- * @property {TileMapTile[]} tiles
- * @property {string?} defaultTileId
+ * @property {string?} tileMapId - Unique ID of the tile map object.
+ * @property {string?} title - Title of the tile map object.
+ * @property {number?} vramOffset - Offset in VRAM for where the tiles for the tile map begin.
+ * @property {number?} rows - Number of rows in the tile map.
+ * @property {number?} columns - Number of columns in the tile map.
+ * @property {boolean?} optimise - When exporting to code, will the tile map be optimised?
+ * @property {boolean?} isSprite - This tile map is a sprite, which will affect the result of export to code operations.
+ * @property {string[]?} paletteSlots - Array of palette IDs for each palette slot.
+ * @property {TileMapTile[]} tiles - Tile map tiles that comprise the tile map.
+ * @property {string?} [defaultTileId] - Tile ID to use when initially populating the tile map tile list.
  * @exports
  */
 

--- a/wwwroot/modules/factory/tileMapFactory.js
+++ b/wwwroot/modules/factory/tileMapFactory.js
@@ -29,7 +29,7 @@ export default class TileMapFactory {
         result.title = (typeof args.title === 'string' && args.title.length > 0) ? args.title : 'Tile map';
         result.vramOffset = (typeof args.vramOffset === 'number') ? args.vramOffset : 0;
         result.optimise = (typeof args.optimise === 'boolean') ? args.optimise : true;
-        result.isSprite = (typeof args.isSprite === 'boolean') ? args.isSprite : true;
+        result.isSprite = (typeof args.isSprite === 'boolean') ? args.isSprite : false;
 
         if (Array.isArray(args.paletteSlots)) {
             args.paletteSlots.forEach((paletteId, index) => {

--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -2103,7 +2103,8 @@ function getPaletteList() {
     return getProject()?.paletteList ?? null;
 }
 /**
- * Gets the palette list for the tile editor based on whether the selected tile grid is a tile set or tile map.
+ * Gets the palette list for the tile editor to used which is based on selected console limitations, as well as
+ * tile map settings, like locking in a colour
  * @returns {PaletteList}
  */
 function getTileEditorPaletteList() {
@@ -2112,14 +2113,15 @@ function getTileEditorPaletteList() {
         // when we exceed the amount of allowed palettes in the tile map, instead just repeat
         // the last selected palette.
         const attr = TileMapUtil.getTileMapAttributes(getTileMap(), getProject());
+        const tileMap = getTileMap();
         const palettes = new Array(16);
         for (let i = 0; i < palettes.length; i++) {
             if (i < attr.paletteSlots) {
                 // Within allowance, add selected palette
-                palettes[i] = getPaletteList().getPalette(i); 
+                palettes[i] = getPaletteList().getPaletteById(tileMap.getPalette(i)); 
             } else {
                 // Exceeds limit, repeat last selected palette
-                palettes[i] = getPaletteList().getPalette(attr.paletteSlots - 1); 
+                palettes[i] = getPaletteList().getPaletteById(tileMap.getPalette(attr.paletteSlots - 1)); 
             }
         }
         return PaletteListFactory.create(palettes);
@@ -2291,6 +2293,7 @@ function refreshProjectUI() {
         tilesPerBlock: getTilesPerBlock(),
         displayNative: getUIState().displayNativeColour,
         transparencyIndex: tileMapAttributes.transparencyIndex,
+        lockedPaletteSlotIndex: tileMapAttributes.lockedIndex,
         selectedTileIndex: instanceState.tileIndex,
         cursorSize: instanceState.pencilSize,
         scale: getUIState().scale,
@@ -2305,7 +2308,8 @@ function refreshProjectUI() {
         tileSet: getTileSet(),
         selectedTileMapId: getProjectUIState().tileMapId,
         selectedTileId: getProjectUIState().tileId,
-        numberOfPaletteSlots: tileMapAttributes.paletteSlots
+        numberOfPaletteSlots: tileMapAttributes.paletteSlots,
+        lockedPaletteSlotIndex: tileMapAttributes.lockedIndex
     });
 
     const toolStrips = TileEditorToolbar.ToolStrips;
@@ -2416,16 +2420,6 @@ function formatForProject() {
         enabled: true
     });
     tileEditor.setState({
-        // palette: palette,
-        // paletteList: getTileEditorPaletteList(),
-        // tileGrid: getTileGrid(),
-        // tileSet: tileSet,
-        // scale: getUIState().scale,
-        // tilesPerBlock: getTilesPerBlock(),
-        // displayNative: getUIState().displayNativeColour,
-        // cursorSize: instanceState.pencilSize,
-        // showTileGrid: getUIState().showTileGrid,
-        // showPixelGrid: getUIState().showPixelGrid,
         enabled: true
     });
     tileContextToolbar.setState({
@@ -4518,13 +4512,15 @@ function updateTileMap(tileMapId, args) {
     tileManager.setState({
         tileMapList: getTileMapList(),
         selectedTileMapId: getProjectUIState().tileMapId,
-        numberOfPaletteSlots: tileMapAttributes.paletteSlots
+        numberOfPaletteSlots: tileMapAttributes.paletteSlots,
+        lockedPaletteSlotIndex: tileMapAttributes.lockedIndex
     });
     tileEditor.setState({
         selectedTileIndex: -1,
         tileGrid: getTileGrid(),
         tileSet: getTileSet(),
         transparencyIndex: tileMapAttributes.transparencyIndex,
+        lockedPaletteSlotIndex: tileMapAttributes.lockedIndex,
         forceRefresh: true
     });
 }

--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -4485,6 +4485,9 @@ function updateTileMap(tileMapId, args) {
     if (typeof args.optimise === 'boolean') {
         tileMap.optimise = args.optimise;
     }
+    if (typeof args.isSprite === 'boolean') {
+        tileMap.isSprite = args.isSprite;
+    }
     if (Array.isArray(args.paletteSlots) && args.paletteSlots.length > 0) {
         args.paletteSlots.forEach((paletteId, index) => {
             tileMap.setPalette(index, paletteId);
@@ -4495,15 +4498,19 @@ function updateTileMap(tileMapId, args) {
     state.setProject(getProject());
     state.saveToLocalStorage();
 
+    const tileMapAttributes = TileMapUtil.getTileMapAttributes(tileMap, getProject());
+
     // Reset UI
     tileManager.setState({
         tileMapList: getTileMapList(),
-        selectedTileMapId: getProjectUIState().tileMapId
+        selectedTileMapId: getProjectUIState().tileMapId,
+        numberOfPaletteSlots: tileMapAttributes.paletteSlots
     });
     tileEditor.setState({
         selectedTileIndex: -1,
         tileGrid: getTileGrid(),
-        tileSet: getTileSet()
+        tileSet: getTileSet(),
+        transparencyIndex: tileMapAttributes.transparencyIndex
     });
 }
 

--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -66,6 +66,7 @@ import ProjectJsonSerialiser from "./serialisers/projectJsonSerialiser.js";
 import KeyboardManager, { KeyDownHandler, KeyUpHandler } from "./components/keyboardManager.js";
 import TileImageManager from "./components/tileImageManager.js";
 import ProjectList from "./models/projectList.js";
+import TileMapUtil from "./util/tileMapUtil.js";
 
 
 /* ****************************************************************************************************
@@ -2266,6 +2267,8 @@ function refreshProjectUI() {
         selectedColourIndex: instanceState.colourIndex
     });
 
+    const tileMapAttributes = TileMapUtil.getTileMapAttributes(getTileMap(), getProject().systemType);
+
     tileEditor.setState({
         forceRefresh: true,
         paletteList: getTileEditorPaletteList(),
@@ -2273,6 +2276,7 @@ function refreshProjectUI() {
         tileGrid: getTileGrid(),
         tilesPerBlock: getTilesPerBlock(),
         displayNative: getUIState().displayNativeColour,
+        transparencyIndex: tileMapAttributes.transparencyIndex,
         selectedTileIndex: instanceState.tileIndex,
         cursorSize: instanceState.pencilSize,
         scale: getUIState().scale,
@@ -2287,7 +2291,7 @@ function refreshProjectUI() {
         tileSet: getTileSet(),
         selectedTileMapId: getProjectUIState().tileMapId,
         selectedTileId: getProjectUIState().tileId,
-        numberOfPaletteSlots: getNumberOfPaletteSlots()
+        numberOfPaletteSlots: tileMapAttributes.paletteSlots
     });
 
     const toolStrips = TileEditorToolbar.ToolStrips;

--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -2108,9 +2108,23 @@ function getPaletteList() {
  */
 function getTileEditorPaletteList() {
     if (isTileMap()) {
-        const palettes = getTileMap().getPalettes().map((paletteId) => getPaletteList().getPaletteById(paletteId));
+        // Tile map, return a palette list of length 16, fill it with selected palettes sequentially
+        // when we exceed the amount of allowed palettes in the tile map, instead just repeat
+        // the last selected palette.
+        const attr = TileMapUtil.getTileMapAttributes(getTileMap(), getProject());
+        const palettes = new Array(16);
+        for (let i = 0; i < palettes.length; i++) {
+            if (i < attr.paletteSlots) {
+                // Within allowance, add selected palette
+                palettes[i] = getPaletteList().getPalette(i); 
+            } else {
+                // Exceeds limit, repeat last selected palette
+                palettes[i] = getPaletteList().getPalette(attr.paletteSlots - 1); 
+            }
+        }
         return PaletteListFactory.create(palettes);
     } else {
+        // With a tile set, just select the palette that is selected in the palette list on the left
         const palette = getPaletteList().getPalette(getProjectUIState().paletteIndex);
         return PaletteListFactory.create([palette]);
     }
@@ -2281,7 +2295,7 @@ function refreshProjectUI() {
         cursorSize: instanceState.pencilSize,
         scale: getUIState().scale,
         showTileGrid: getUIState().showTileGrid,
-        showPixelGrid: getUIState().showPixelGrid,
+        showPixelGrid: getUIState().showPixelGrid
     });
 
     tileManager.setState({
@@ -4510,7 +4524,8 @@ function updateTileMap(tileMapId, args) {
         selectedTileIndex: -1,
         tileGrid: getTileGrid(),
         tileSet: getTileSet(),
-        transparencyIndex: tileMapAttributes.transparencyIndex
+        transparencyIndex: tileMapAttributes.transparencyIndex,
+        forceRefresh: true
     });
 }
 

--- a/wwwroot/modules/models/tileMap.js
+++ b/wwwroot/modules/models/tileMap.js
@@ -3,19 +3,29 @@ import TileGridProvider from './tileGridProvider.js';
 import TileMapTileFactory from "../factory/tileMapTileFactory.js";
 
 /**
- * Tile map.
+ * Represents a tile map, which is a structured collection of tiles with attributes. 
+ * Extends TileGridProvider.
  */
 export default class TileMap extends TileGridProvider {
 
     
+    /**
+     * Gets whether this is a tile set (part of TileGridProvider).
+     */
     get isTileSet() {
         return false;
     }
 
+    /**
+     * Gets whether this is a tile map (part of TileGridProvider).
+     */
     get isTileMap() {
         return true;
     }
 
+    /**
+     * Gets or sets the unique ID of the tile map.
+     */
     get tileMapId() {
         return this.#tileMapId;
     }
@@ -23,6 +33,9 @@ export default class TileMap extends TileGridProvider {
         this.#tileMapId = value;
     }
 
+    /**
+     * Gets or sets the unique ID of the tile.
+     */
     get title() {
         return this.#title;
     }
@@ -30,6 +43,9 @@ export default class TileMap extends TileGridProvider {
         this.#title = value;
     }
 
+    /**
+     * Gets or sets the tile offset in VRAM.
+     */
     get vramOffset() {
         return this.#vramOffset;
     }
@@ -37,23 +53,47 @@ export default class TileMap extends TileGridProvider {
         this.#vramOffset = value;
     }
 
+    /**
+     * Gets the column count.
+     */
     get columnCount() {
         return this.#columns;
     }
 
+    /**
+     * Gets the row count.
+     */
     get rowCount() {
         return this.#rows;
     }
 
+    /**
+     * Gets the tile count.
+     */
     get tileCount() {
         return this.#tiles.length;
     }
 
+    /**
+     * Gets whether the tile map will be optimised on export.
+     * The results of this vary per system.
+     */
     get optimise() {
         return this.#optimise;
     }
     set optimise(value) {
         this.#optimise = value;
+    }
+
+    /**
+     * Gets whether the tile map is to be treated as a sprite which will have an effect on 
+     * the code export of the tile map.
+     */
+    get isSprite() {
+        return this.#isSprite;
+    }
+    set isSprite(value) {
+        this.#isSprite = value;
     }
 
 
@@ -66,12 +106,13 @@ export default class TileMap extends TileGridProvider {
     #columns = 1;
     #rows = 1;
     #optimise = false;
+    #isSprite = false;
     /** @type {TileMapTile[]} */
     #tiles;
 
 
     /**
-     * Initialises a new instanve of the tile map class.
+     * Constructor for the class.
      * @param {number} rows - Initial number of rows for the tile map, default is '1'.
      * @param {number} columns - Initial number of columns for the tile map, default is '1'.
      */
@@ -421,52 +462,6 @@ export default class TileMap extends TileGridProvider {
             tileIndex: tileIndex
         };
     }
-
-    // /**
-    //  * Adds a tile to the tile set.
-    //  * @param {Tile} tile - Tile reference to add.
-    //  * @param {TileMapTileParams} params - Parameters.
-    //  */
-    // addTile(tile, params) {
-    //     this.#tiles.push({
-    //         tileIndex: this.#tiles.length,
-    //         sourceTile: tile,
-    //         horizontalFlip: params.horizontalFlip,
-    //         verticalFlip: params.verticalFlip,
-    //         palette: params.palette,
-    //         priority: params.priority
-    //     });
-    // }
-
-    // getTileMapTiles() {
-    //     return this.#tiles.map((tileMapTile) => {
-    //         /** @type {TileMapTile} */
-    //         const result = {
-    //             tileIndex: tileMapTile.tileIndex + this.vramOffset,
-    //             horizontalFlip: tileMapTile.horizontalFlip,
-    //             verticalFlip: tileMapTile.verticalFlip,
-    //             palette: tileMapTile.palette,
-    //             priority: tileMapTile.priority
-    //         };
-    //         return result;
-    //     });
-    // }
-
-
-    // toTileSet() {
-    //     const result = new TileSet();
-    //     result.tileWidth = this.columns;
-    //     if (!this.optimise) {
-    //         this.#tiles.forEach((tile) => {
-    //             result.addTile(tile.sourceTile);
-    //         });
-    //     } else {
-    //         Object.keys(this.#uniqueTiles).forEach(key => {
-    //             result.addTile(this.#uniqueTiles[key].tile);
-    //         });
-    //     }
-    //     return result;
-    // }
 
 
 }

--- a/wwwroot/modules/serialisers/tileMapJsonSerialiser.js
+++ b/wwwroot/modules/serialisers/tileMapJsonSerialiser.js
@@ -43,6 +43,7 @@ export default class TileMapJsonSerialiser {
             rows: tileMap.rowCount,
             columns: tileMap.columnCount,
             optimise: tileMap.optimise,
+            isSprite: tileMap.isSprite,
             paletteSlots: tileMap.getPalettes(),
             tiles: tileMap.getTiles().map((tile) => TileMapTileJsonSerialiser.toSerialisable(tile))
         };
@@ -61,6 +62,7 @@ export default class TileMapJsonSerialiser {
             rows: tileMapSerialisable.rows,
             columns: tileMapSerialisable.columns,
             optimise: tileMapSerialisable.optimise,
+            isSprite: tileMapSerialisable.isSprite ?? false,
             paletteSlots: tileMapSerialisable.paletteSlots
         });
         if (Array.isArray(tileMapSerialisable.tiles)) {
@@ -84,6 +86,7 @@ export default class TileMapJsonSerialiser {
  * @property {number} rows
  * @property {number} columns
  * @property {boolean} optimise
+ * @property {boolean} isSprite
  * @property {string[]} paletteSlots
  * @property {import('./tileMapTileJsonSerialiser.js').TileMapTileSerialisable[]} tiles
  * @exports

--- a/wwwroot/modules/types.js
+++ b/wwwroot/modules/types.js
@@ -23,3 +23,10 @@ export const Types = {};
  * @property {string} direction - Either 'asc' or 'desc'.
  * @exports
  */
+
+/**
+ * @typedef {Object} TileMapAttributes
+ * @property {number?} transparencyIndex - Colour index that is to be rendered as transparent.
+ * @property {number?} paletteSlots - Number of palette slots available to the tile map.
+ * @exports
+ */

--- a/wwwroot/modules/types.js
+++ b/wwwroot/modules/types.js
@@ -28,5 +28,6 @@ export const Types = {};
  * @typedef {Object} TileMapAttributes
  * @property {number?} transparencyIndex - Colour index that is to be rendered as transparent.
  * @property {number?} paletteSlots - Number of palette slots available to the tile map.
+ * @property {number?} lockedIndex - Locked palette index, if this is set, this colour index will be repeated across all palettes.
  * @exports
  */

--- a/wwwroot/modules/ui/tileEditor.js
+++ b/wwwroot/modules/ui/tileEditor.js
@@ -269,6 +269,12 @@ export default class TileEditor extends ComponentBase {
             this.#canvasManager.invalidateImage();
             refreshTiles = true;
         }
+        // Locked palette slot index
+        if (typeof state.lockedPaletteSlotIndex === 'number' || state.lockedPaletteSlotIndex === null) {
+            this.#canvasManager.lockedPaletteSlotIndex = state.lockedPaletteSlotIndex ?? -1;
+            this.#canvasManager.invalidateImage();
+            refreshTiles = true;
+        }
         // Theme
         if (typeof state?.theme === 'string') {
             if (state.theme === 'light') {
@@ -668,6 +674,7 @@ export default class TileEditor extends ComponentBase {
  * @property {number?} [viewportPanVertical] - Pan the viewport vertically.
  * @property {ReferenceImage?} referenceImage - Reference image to draw.
  * @property {number?} transparencyIndex - 0 to 15 of which colour index to make transparent.
+ * @property {number?} [lockedPaletteSlotIndex] - When not null, the palette slot index specified here will be repeated from palette 0 across all palettes.
  * @property {boolean?} showTileGrid - Should the tile grid be drawn?
  * @property {boolean?} showPixelGrid - Should the pixel grid be drawn?
  * @property {boolean?} enabled - Is the control enabled or disabled?

--- a/wwwroot/modules/ui/tileEditor.js
+++ b/wwwroot/modules/ui/tileEditor.js
@@ -264,8 +264,8 @@ export default class TileEditor extends ComponentBase {
             refreshTiles = true;
         }
         // Transparency index
-        if (typeof state?.transparencyIndex === 'number') {
-            this.#canvasManager.transparencyIndex = state.transparencyIndex;
+        if (typeof state.transparencyIndex === 'number' || state.transparencyIndex === null) {
+            this.#canvasManager.transparencyIndex = state.transparencyIndex ?? -1;
             this.#canvasManager.invalidateImage();
             refreshTiles = true;
         }
@@ -313,6 +313,7 @@ export default class TileEditor extends ComponentBase {
         // Force refresh?
         if (typeof state.forceRefresh === 'boolean' && state.forceRefresh === true) {
             refreshTiles = true;
+            this.#canvasManager.invalidateImage();
         }
         // Refresh image?
         if ((refreshTiles || redrawUI) && this.#tileGrid && this.#tileSet && this.#paletteList && this.#paletteList.length > 0) {

--- a/wwwroot/modules/ui/tileEditor.js
+++ b/wwwroot/modules/ui/tileEditor.js
@@ -11,6 +11,7 @@ import PaletteList from "../models/paletteList.js";
 import TileGridProvider from "../models/tileGridProvider.js";
 import TileImageManager from "../components/tileImageManager.js";
 
+
 const EVENT_OnCommand = 'EVENT_OnCommand';
 const EVENT_OnEvent = 'EVENT_OnEvent';
 
@@ -29,17 +30,30 @@ const events = {
     pixelMouseUp: 'pixelMouseUp'
 }
 
+
+/**
+ * Manages and renders the tile editor including rendered tile image and toolbars.
+ */
 export default class TileEditor extends ComponentBase {
 
 
+    /**
+     * Gets a list of commands this component can invoke.
+     */
     static get Commands() {
         return commands;
     }
 
+    /**
+     * Gets a list of events this component can raise.
+     */
     static get Events() {
         return events;
     }
 
+    /**
+     * Gets a list of canvas highlight modes that this object can accept.
+     */
     static get CanvasHighlightModes() {
         return CanvasManager.HighlightModes;
     }
@@ -76,7 +90,7 @@ export default class TileEditor extends ComponentBase {
 
 
     /**
-     * Initialises a new instance of this class.
+     * Constructor for the class.
      * @param {HTMLElement} element - Element that contains the DOM.
      */
     constructor(element) {

--- a/wwwroot/modules/ui/tileManager.html
+++ b/wwwroot/modules/ui/tileManager.html
@@ -74,6 +74,19 @@
                     {{/each}}
                 </script>
                 </div>
+                <div data-smsgfx-id="tile-map-is-sprite" class="row">
+                    <div class="col">
+                        <div class="form-check form-switch">
+                            <input id="tileMapIsSprite" data-command="tileMapChange" data-auto-event="change"
+                                data-field="isSprite" class="form-check-input" type="checkbox" role="switch" checked
+                                title="Marking the tile map as a sprite applies specific attributes to it that affect the export process.">
+                            <label class="form-check-label" for="tileMapIsSprite"
+                                title="Marking the tile map as a sprite applies specific attributes to it that affect the export process.">
+                                Is sprite
+                            </label>
+                        </div>
+                    </div>
+                </div>
                 <div data-smsgfx-id="tile-map-optimise" class="row">
                     <div class="col">
                         <div class="form-check form-switch">

--- a/wwwroot/modules/ui/tileManager.js
+++ b/wwwroot/modules/ui/tileManager.js
@@ -28,6 +28,7 @@ const commands = {
 const fields = {
     tileMapTitle: 'tileMapTitle',
     tileMapOptimise: 'tileMapOptimise',
+    tileMapIsSprite: 'tileMapIsSprite',
     tileMapPaletteId: 'tileMapPaletteId',
     tileWidth: 'tileWidth'
 }
@@ -63,6 +64,8 @@ export default class TileManager extends ComponentBase {
     #uiTileMapTitle;
     /** @type {HTMLInputElement} */
     #uiTileSetOptimise;
+    /** @type {HTMLInputElement} */
+    #uiTileSetIsSprite;
     /** @type {HTMLButtonElement} */
     #btnTileSetSelect;
     /** @type {HTMLButtonElement} */
@@ -96,6 +99,7 @@ export default class TileManager extends ComponentBase {
 
         this.#uiTileSetTileWidth = this.#element.querySelector('[data-command=tileSetChange][data-field=tileWidth]');
         this.#uiTileSetOptimise = this.#element.querySelector('[data-command=tileMapChange][data-field=optimise]');
+        this.#uiTileSetIsSprite = this.#element.querySelector('[data-command=tileMapChange][data-field=isSprite]');
 
         this.#uiTileMapTitle = this.#element.querySelector('[data-command=tileMapChange][data-field=title]');
         this.#uiTileMapTitle.addEventListener('blur', () => this.#handleTileMapTitleEditBlur());
@@ -249,6 +253,7 @@ export default class TileManager extends ComponentBase {
             result.tileMapId = this.#selectedTileMapId;
             result.title = this.#uiTileMapTitle.value;
             result.optimise = this.#uiTileSetOptimise.checked;
+            result.isSprite = this.#uiTileSetIsSprite.checked;
             result.paletteSlots = [];
             for (let i = 0; i < this.#numberOfPaletteSlots; i++) {
                 const select = this.#element.querySelector(`[data-command='tileMapChange'][data-field='paletteId'][data-palette-slot='${i}']`);
@@ -516,6 +521,7 @@ export default class TileManager extends ComponentBase {
  * @property {number?} [paletteSlotNumber] - Slot number for the palette.
  * @property {string[]?} [paletteSlots] - Unique ID of the palette.
  * @property {boolean?} [optimise] - Optimise the tile map?
+ * @property {boolean?} [isSprite] - Is this tile map a sprite?
  * @property {number?} [tileWidth] - Display tile width for the tile set.
  * @exports
  */

--- a/wwwroot/modules/util/tileMapUtil.js
+++ b/wwwroot/modules/util/tileMapUtil.js
@@ -168,23 +168,23 @@ export default class TileMapUtil {
     static getTileMapAttributes(tileMap, projectOrSystemType) {
         const systemType = projectOrSystemType instanceof Project ? projectOrSystemType.systemType : projectOrSystemType;
         if (systemType === 'smsgg' && tileMap === null) {
-            return { paletteSlots: 2, transparencyIndex: null };
+            return { paletteSlots: 2, transparencyIndex: null, lockedIndex: null };
         } else if (systemType === 'smsgg' && tileMap.isSprite) {
-            return { paletteSlots: 1, transparencyIndex: 0 };
+            return { paletteSlots: 1, transparencyIndex: 0, lockedIndex: null };
         } else if (systemType === 'smsgg' && !tileMap.isSprite) {
-            return { paletteSlots: 2, transparencyIndex: null };
+            return { paletteSlots: 2, transparencyIndex: null, lockedIndex: null };
         } else if (systemType === 'gb' && tileMap === null) {
-            return { paletteSlots: 1, transparencyIndex: null };
+            return { paletteSlots: 1, transparencyIndex: null, lockedIndex: null };
         } else if (systemType === 'gb' && tileMap.isSprite) {
-            return { paletteSlots: 1, transparencyIndex: 0 };
+            return { paletteSlots: 1, transparencyIndex: 0, lockedIndex: null };
         } else if (systemType === 'gb' && !tileMap.isSprite) {
-            return { paletteSlots: 1, transparencyIndex: null };
+            return { paletteSlots: 1, transparencyIndex: null, lockedIndex: null };
         } else if (systemType === 'nes' && tileMap === null) {
-            return { paletteSlots: 4, transparencyIndex: null };
+            return { paletteSlots: 4, transparencyIndex: null, lockedIndex: 0 };
         } else if (systemType === 'nes' && tileMap.isSprite) {
-            return { paletteSlots: 4, transparencyIndex: 0 };
+            return { paletteSlots: 4, transparencyIndex: 0, lockedIndex: 0 };
         } else if (systemType === 'nes' && !tileMap.isSprite) {
-            return { paletteSlots: 4, transparencyIndex: null };
+            return { paletteSlots: 4, transparencyIndex: null, lockedIndex: 0 };
         } throw new Error('Unknown project system type.');
     }
 

--- a/wwwroot/modules/util/tileMapUtil.js
+++ b/wwwroot/modules/util/tileMapUtil.js
@@ -1,6 +1,5 @@
 import TileMapListFactory from "../factory/tileMapListFactory.js";
 import PaletteList from "../models/paletteList.js";
-import Tile from "../models/tile.js";
 import TileMap from "../models/tileMap.js";
 import TileMapList from "../models/tileMapList.js";
 import TileSet from "../models/tileSet.js";
@@ -13,6 +12,10 @@ import Project from "../models/project.js";
 import TileMapFactory from "../factory/tileMapFactory.js";
 import TileMapTileFactory from "../factory/tileMapTileFactory.js";
 
+
+/**
+ * Provides tile map related utility functions.
+ */
 export default class TileMapUtil {
 
 
@@ -153,6 +156,36 @@ export default class TileMapUtil {
             tileSet: optimisedTileSet,
             tileMaps: optimisedTileMapList
         };
+    }
+
+
+    /**
+     * Gets attributes relating to a given tile map.
+     * @param {TileMap|null} tileMap - Tile map to provide attributes for, or null to accept default system values.
+     * @param {Project|string} projectOrSystemType - Either a project or the system type that the tile map belongs to.
+     * @returns {import('./../types.js').TileMapAttributes}
+     */
+    static getTileMapAttributes(tileMap, projectOrSystemType) {
+        const systemType = projectOrSystemType instanceof Project ? projectOrSystemType.systemType : projectOrSystemType;
+        if (systemType === 'smsgg' && tileMap === null) {
+            return { paletteSlots: 2, transparencyIndex: null };
+        } else if (systemType === 'smsgg' && tileMap.isSprite) {
+            return { paletteSlots: 1, transparencyIndex: 0 };
+        } else if (systemType === 'smsgg' && !tileMap.isSprite) {
+            return { paletteSlots: 2, transparencyIndex: null };
+        } else if (systemType === 'gb' && tileMap === null) {
+            return { paletteSlots: 1, transparencyIndex: null };
+        } else if (systemType === 'gb' && tileMap.isSprite) {
+            return { paletteSlots: 1, transparencyIndex: 0 };
+        } else if (systemType === 'gb' && !tileMap.isSprite) {
+            return { paletteSlots: 1, transparencyIndex: null };
+        } else if (systemType === 'nes' && tileMap === null) {
+            return { paletteSlots: 4, transparencyIndex: null };
+        } else if (systemType === 'nes' && tileMap.isSprite) {
+            return { paletteSlots: 4, transparencyIndex: 0 };
+        } else if (systemType === 'nes' && !tileMap.isSprite) {
+            return { paletteSlots: 4, transparencyIndex: null };
+        } throw new Error('Unknown project system type.');
     }
 
 


### PR DESCRIPTION
- Implemented "Is sprite" option for tile maps.
  - Render colour 0 as transparent when its a sprite.
  - Save state to tile map.

- On NES, first colour of first palette now applies to all other palettes in tile map.