### PR TITLE
Bugfixes

### DIFF
--- a/wwwroot/modules/components/canvasManager.js
+++ b/wwwroot/modules/components/canvasManager.js
@@ -1232,6 +1232,12 @@ export default class CanvasManager {
      * @param {CanvCoords} coords 
      */
     #drawReferenceImages(context, coords) {
+        const originalSmoothingEnabled = context.imageSmoothingEnabled;
+        const originalSmoothingQuality = context.imageSmoothingQuality;
+
+        context.imageSmoothingEnabled = true;
+        context.imageSmoothingQuality = 'high';
+
         const pxSize = coords.pxSize;
         context.globalAlpha = 0.5;
         this.#referenceImages.forEach(ref => {
@@ -1243,7 +1249,10 @@ export default class CanvasManager {
             }
         });
         context.globalAlpha = 1;
-    }
+  
+        context.imageSmoothingEnabled = originalSmoothingEnabled;
+        context.imageSmoothingQuality = originalSmoothingQuality;
+  }
 
     /**
      * @param {CanvasRenderingContext2D} context 

--- a/wwwroot/modules/factory/paletteFactory.js
+++ b/wwwroot/modules/factory/paletteFactory.js
@@ -220,9 +220,9 @@ export default class PaletteFactory {
  */
 
 
-const defaultColoursMS = ['#000000', '#000000', '#00AA00', '#00FF00', '#000055', '#0000FF', '#550000', '#00FFFF', '#AA0000', '#FF0000', '#555500', '#FFFF00', '#005500', '#FF00FF', '#555555', '#FFFFFF'];
-const defaultColoursGB = ['#000000', '#555555', '#AAAAAA', '#FFFFFF'];
-const defaultColourNES = ['#000000', '#38b4cc', '#3032ec', '#FFFFFF'];
+const defaultColoursMS = ['#FFFFFF', '#000000', '#FFFFFF', '#555555', '#00AA00', '#00FF00', '#000055', '#0000FF', '#FF0000', '#550000', '#FFFF00', '#FF5500', '#FF00FF', '#FF0055', '#00AAAA', '#005555'];
+const defaultColoursGB = ['#FFFFFF', '#AAAAAA', '#555555', '#000000'];
+const defaultColourNES = ['#FFFFFF', '#3032ec', '#38b4cc', '#000000'];
 
 /**
  * Gets the colour that corresponds with the NES colour code.

--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -1659,6 +1659,9 @@ function handleImportPaletteModalDialogueOnConfirm(args) {
         paletteList: getPaletteList(),
         selectedPaletteIndex: getProjectUIState().paletteIndex
     });
+    tileManager.setState({
+        paletteList: getPaletteList()
+    });
     tileEditor.setState({
         paletteList: getPaletteListToSuitTileMapOrTileSetSelection()
     });
@@ -3658,6 +3661,13 @@ function paletteNew() {
 
         state.saveToLocalStorage();
 
+        paletteEditor.setState({
+            paletteList: getPaletteList()
+        });
+        tileManager.setState({
+            paletteList: getPaletteList()
+        });
+
         changePalette(newPalette.paletteId);
         toast.show('Palette created.');
     } catch (e) {
@@ -3679,6 +3689,13 @@ function paletteClone(paletteIndex) {
 
             state.saveToLocalStorage();
 
+            paletteEditor.setState({
+                paletteList: getPaletteList()
+            });
+            tileManager.setState({
+                paletteList: getPaletteList()
+            });
+    
             changePalette(newPalette.paletteId);
 
             toast.show('Palette cloned.');
@@ -3714,7 +3731,10 @@ function paletteDelete(paletteIndex) {
             tileManager.setState({
                 paletteList: getPaletteList()
             });
-
+            tileEditor.setState({
+                paletteList: getPaletteListToSuitTileMapOrTileSetSelection()
+            });
+        
             const palette = getPaletteList().getPalette(paletteIndex);
             changePalette(palette.paletteId);
 

--- a/wwwroot/modules/util/paintUtil.js
+++ b/wwwroot/modules/util/paintUtil.js
@@ -337,8 +337,8 @@ export default class PaintUtil {
         let tilePixelIndex = 0;
         let scaleX = width / 8;
         let scaleY = height / 8;
-        let canvasX = hFlip ? x + (scaleX * 7) - 1 : x;
-        let canvasY = vflip ? y + (scaleY * 7) - 1 : y;
+        let canvasX = hFlip ? x + (scaleX * 7) : x;
+        let canvasY = vflip ? y + (scaleY * 7) : y;
 
         for (let tileY = 0; tileY < 8; tileY++) {
             for (let tileX = 0; tileX < 8; tileX++) {
@@ -365,7 +365,7 @@ export default class PaintUtil {
                 canvasX += hFlip ? -scaleX : scaleX;
             }
             canvasY += vflip ? -scaleY : scaleY;
-            canvasX = hFlip ? x + (scaleX * 7) - 1: x;
+            canvasX = hFlip ? x + (scaleX * 7): x;
         }
     }
 

--- a/wwwroot/modules/util/paintUtil.js
+++ b/wwwroot/modules/util/paintUtil.js
@@ -169,8 +169,8 @@ export default class PaintUtil {
             y = y % 8;
         }
 
-        const coords = translateCoordinate(tileInfo, x % 8, y % 8);
-        const originColour = tile.readAtCoord(coords.x, coords.y);
+        const coord = translateCoordinate(tileInfo, x % 8, y % 8);
+        const originColour = tile.readAtCoord(coord.x, coord.y);
         if (originColour === null || originColour === fillColour) return { affectedTileIds: [], affectedTileIndexes: [] };
 
         const updatedTileIds = {};
@@ -179,19 +179,19 @@ export default class PaintUtil {
         /** @type {FillProps} */
         const props = { tileGrid, tileSet, w, h, originColour };
 
-        if (pxIsInsideImageAndMatchesOriginColour(x, y, props)) {
+        if (pxIsInsideImageAndMatchesOriginColour(coord.x, coord.y, props)) {
 
             /** @type {Coordinate[]} */
-            let scanCoords = [{ x, y }];
+            let scanCoords = [{ x: coord.x, y: coord.y }];
             while (scanCoords.length > 0) {
 
                 const scanCoord = scanCoords.pop();
-                const y = scanCoord.y;
+                const scanY = scanCoord.y;
 
                 // Fill left of the origin
                 let leftX = scanCoord.x;
-                while (pxIsInsideImageAndMatchesOriginColour(pxToLeftOf(leftX), y, props)) {
-                    const result = setColourOnPixel(tileGrid, tileSet, pxToLeftOf(leftX), y, fillColour);
+                while (pxIsInsideImageAndMatchesOriginColour(pxToLeftOf(leftX), scanY, props)) {
+                    const result = setColourOnPixel(tileGrid, tileSet, pxToLeftOf(leftX), scanY, fillColour);
                     if (result.wasUpdated) {
                         updatedTileIds[result.tileId] = result.tileId;
                         updatedTileIndexes[result.tileIndex] = result.tileIndex;
@@ -201,8 +201,8 @@ export default class PaintUtil {
 
                 // Fill right of the origin
                 let rightX = scanCoord.x - 1;
-                while (pxIsInsideImageAndMatchesOriginColour(pxToRightOf(rightX), y, props)) {
-                    const result = setColourOnPixel(tileGrid, tileSet, pxToRightOf(rightX), y, fillColour);
+                while (pxIsInsideImageAndMatchesOriginColour(pxToRightOf(rightX), scanY, props)) {
+                    const result = setColourOnPixel(tileGrid, tileSet, pxToRightOf(rightX), scanY, fillColour);
                     if (result.wasUpdated) {
                         updatedTileIds[result.tileId] = result.tileId;
                         updatedTileIndexes[result.tileIndex] = result.tileIndex;
@@ -213,8 +213,8 @@ export default class PaintUtil {
                 // Now scan the line above and below this one, if any matching pixels 
                 // found then add them to the coords list
                 scanCoords = scanCoords
-                    .concat(scanLineForBlocksOfPixelsWithSameOriginColour(leftX, rightX, oneBelow(y), props))
-                    .concat(scanLineForBlocksOfPixelsWithSameOriginColour(leftX, rightX, oneAbove(y), props));
+                    .concat(scanLineForBlocksOfPixelsWithSameOriginColour(leftX, rightX, oneBelow(scanY), props))
+                    .concat(scanLineForBlocksOfPixelsWithSameOriginColour(leftX, rightX, oneAbove(scanY), props));
             }
 
         }


### PR DESCRIPTION
The following issues were resolved: 
#247, #256, #257, #246, #250, #249 

- Reference image no longer goes aliased when mouse cursor over the tile editor.
- Default palette list updated for all systems, index 0 is always white.
- Send updates to palette list to components that consume a palette list.
- Send updates to individual palettes to components that require them.
- Fix issue with draw offset for horizontally and vertically flipped tiles.
- Paint bucket origin coordinates were not being translated correctly when the tile was flipped on H or V axis.
- Refactoring to remove some variable ambiguity.