### PR TITLE
Add sort options to the palette editor and tile manager

### DIFF
--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -3675,12 +3675,7 @@ function paletteNew() {
 
         state.saveToLocalStorage();
 
-        paletteEditor.setState({
-            paletteList: getPaletteList()
-        });
-        tileManager.setState({
-            paletteList: getPaletteList()
-        });
+        updatePaletteLists({ skipTileEditor: true });
 
         changePalette(newPalette.paletteId);
         toast.show('Palette created.');
@@ -3703,12 +3698,7 @@ function paletteClone(paletteIndex) {
 
             state.saveToLocalStorage();
 
-            paletteEditor.setState({
-                paletteList: getPaletteList()
-            });
-            tileManager.setState({
-                paletteList: getPaletteList()
-            });
+            updatePaletteLists({ skipTileEditor: true });
 
             changePalette(newPalette.paletteId);
 
@@ -3739,15 +3729,7 @@ function paletteDelete(paletteIndex) {
 
             state.saveToLocalStorage();
 
-            paletteEditor.setState({
-                paletteList: getPaletteList()
-            });
-            tileManager.setState({
-                paletteList: getPaletteList()
-            });
-            tileEditor.setState({
-                paletteList: getPaletteListToSuitTileMapOrTileSetSelection()
-            });
+            updatePaletteLists();
 
             const palette = getPaletteList().getPalette(paletteIndex);
             changePalette(palette.paletteId);
@@ -3809,6 +3791,10 @@ function paletteListSort(field) {
     updatePaletteLists();
 }
 
+/**
+ * 
+ * @param {{ skipTileEditor: boolean }} args 
+ */
 function updatePaletteLists(args) {
     paletteEditor.setState({
         paletteList: getPaletteList()
@@ -3816,9 +3802,11 @@ function updatePaletteLists(args) {
     tileManager.setState({
         paletteList: getPaletteList()
     });
-    tileEditor.setState({
-        paletteList: getPaletteListToSuitTileMapOrTileSetSelection()
-    });
+    if (args?.skipTileEditor !== true) {
+        tileEditor.setState({
+            paletteList: getPaletteListToSuitTileMapOrTileSetSelection()
+        });
+    }
 }
 
 function paletteImportFromAssembly() {

--- a/wwwroot/modules/models/paletteList.js
+++ b/wwwroot/modules/models/paletteList.js
@@ -39,11 +39,11 @@ export default class PaletteList {
 
     /**
      * Sets the items in the list.
-     * @param {Palette[]} array 
+     * @param {Palette[]} values - Array of values.
      */
-    setPalettes(array) {
-        if (Array.isArray(array)) {
-            const filtered = array.filter((palette) => palette !== null && palette instanceof Palette);
+    setPalettes(values) {
+        if (Array.isArray(values)) {
+            const filtered = values.filter((palette) => palette !== null && palette instanceof Palette);
             this.#palettes = filtered;
         }
     }

--- a/wwwroot/modules/models/paletteList.js
+++ b/wwwroot/modules/models/paletteList.js
@@ -38,6 +38,18 @@ export default class PaletteList {
     }
 
     /**
+     * Sets the items in the list.
+     * @param {Palette[]} array 
+     */
+    setPalettes(array) {
+        if (Array.isArray(array)) {
+            const filtered = array.filter((palette) => palette !== null && palette instanceof Palette);
+            this.#palettes = filtered;
+        }
+    }
+
+
+    /**
      * Gets an item by index.
      * @param {number} index - Index of the item to get.
      * @returns {Palette}

--- a/wwwroot/modules/models/tileMapList.js
+++ b/wwwroot/modules/models/tileMapList.js
@@ -36,6 +36,18 @@ export default class TileMapList {
     }
 
     /**
+     * Sets the items in the list.
+     * @param {TileMap[]} values - Array of values.
+     */
+    setTileMaps(values) {
+        if (Array.isArray(values)) {
+            const filtered = values.filter((tileMap) => tileMap !== null && tileMap instanceof TileMap);
+            this.#tileMaps = filtered;
+        }
+    }
+
+
+    /**
      * Gets whether the project contains a tile map by ID.
      * @param {string} tileMapId - ID of the item to check.
      * @returns {boolean}

--- a/wwwroot/modules/ui/paletteEditor.html
+++ b/wwwroot/modules/ui/paletteEditor.html
@@ -17,8 +17,10 @@
             data-bs-toggle="dropdown" aria-expanded="false" title="Select an existing palette to edit."></button>
         <ul data-smsgfx-id="paletteSelectVirtualList" data-linked-command="paletteSelect"
             class="sms-dropdown-menu dropdown-menu dropdown-menu-end">
-            <li><a data-command="sort" data-field="title" data-auto-event="click" class="dropdown-item" href="#">Sory by title</a></li>
-            <li><a data-command="sort" data-field="system" data-auto-event="click" class="dropdown-item" href="#">Sort by system</a></li>
+            <li><a data-command="sort" data-field="title" data-auto-event="click" class="dropdown-item" href="#">Sort by
+                    title</a></li>
+            <li><a data-command="sort" data-field="system" data-auto-event="click" class="dropdown-item" href="#">Sort
+                    by system</a></li>
             <li>
                 <hr class="dropdown-divider">
             </li>

--- a/wwwroot/modules/ui/paletteEditor.html
+++ b/wwwroot/modules/ui/paletteEditor.html
@@ -15,7 +15,13 @@
         </button>
         <button class="btn btn-outline-secondary dropdown-toggle btn-ui border border-0 border-start" type="button"
             data-bs-toggle="dropdown" aria-expanded="false" title="Select an existing palette to edit."></button>
-        <ul data-linked-command="paletteSelect" class="sms-dropdown-menu dropdown-menu dropdown-menu-end">
+        <ul data-smsgfx-id="paletteSelectVirtualList" data-linked-command="paletteSelect"
+            class="sms-dropdown-menu dropdown-menu dropdown-menu-end">
+            <li><a data-command="sort" data-field="title" data-auto-event="click" class="dropdown-item" href="#">Sory by title</a></li>
+            <li><a data-command="sort" data-field="system" data-auto-event="click" class="dropdown-item" href="#">Sort by system</a></li>
+            <li>
+                <hr class="dropdown-divider">
+            </li>
         </ul>
     </div>
     <!-- End: Palette editor : header -->
@@ -48,9 +54,9 @@
                             class="p-2 ps-0 fw-bold text-body-emphasis text-start overflow-hidden text-nowrap flex-shrink w-100">Title</label>
                         <span class="p-2"><i class="bi bi-pencil-fill"></i></span>
                     </button>
-                    <input data-smsgfx-id="paletteTitle" data-command="paletteTitle" data-auto-event="change" data-field="title" type="text"
-                        class="form-control visually-hidden mt-2" aria-label="Enter name" list="tbPaletteSelect"
-                        title="Change the title of the palette.">
+                    <input data-smsgfx-id="paletteTitle" data-command="paletteTitle" data-auto-event="change"
+                        data-field="title" type="text" class="form-control visually-hidden mt-2" aria-label="Enter name"
+                        list="tbPaletteSelect" title="Change the title of the palette.">
                 </div>
             </div>
             <select data-command="paletteSystem" class="form-select form-select-sm visually-hidden"
@@ -84,7 +90,8 @@
                             </button>
                         </li>
                         <li class="nav-item">
-                            <button data-linked-command="paletteSystem" data-value="nes" class="nav-link visually-hidden"
+                            <button data-linked-command="paletteSystem" data-value="nes"
+                                class="nav-link visually-hidden"
                                 title="This palette is for Nintendo Entertainment System.">
                                 NES
                             </button>

--- a/wwwroot/modules/ui/paletteEditor.js
+++ b/wwwroot/modules/ui/paletteEditor.js
@@ -413,10 +413,6 @@ export default class PaletteEditor extends ComponentBase {
                 node.remove();
             });
 
-            // while (virtualList.childNodes.length > 0) {
-            //     virtualList.childNodes.item(0).remove();
-            // }
-
             // Create the new options
             select.querySelectorAll('option').forEach((option, index) => {
                 const paletteId = option.getAttribute('data-palette-id');
@@ -662,6 +658,6 @@ export default class PaletteEditor extends ComponentBase {
  * @property {number?} colourIndex - Index from 0 to 15 for the given colour.
  * @property {number?} targetColourIndex - Target palette colour index from 0 to 15 for 'ms' and 'gg', 0 to 3 for 'gb' or 'nes'.
  * @property {boolean?} displayNative - Display native colours for system?
- * @property {string?} [field] - Index of the selected palette.
+ * @property {string?} [field] - Field to sort by.
  * @exports
  */

--- a/wwwroot/modules/ui/tileManager.html
+++ b/wwwroot/modules/ui/tileManager.html
@@ -12,7 +12,17 @@
             <button class="btn btn-outline-secondary dropdown-toggle btn-ui border border-0 border-start" type="button"
                 data-bs-toggle="dropdown" aria-expanded="false" title="Select an existing tile map to edit."></button>
             <ul data-smsgfx-id="tileMapSelectDropDown" class="dropdown-menu">
-            </ul>
+                <li><a data-command="sort" data-field="title" data-auto-event="click" class="dropdown-item"
+                        href="#">Sort by title</a></li>
+                <li>
+                    <hr class="dropdown-divider">
+                </li>
+                <li><a data-command="tileSetSelect" data-auto-event="click" class="dropdown-item"
+                    href="#">Edit tile set</a></li>
+            <li>
+                <hr class="dropdown-divider">
+            </li>
+        </ul>
         </div>
 
         <div class="overflow-hidden overflow-y-auto">
@@ -135,7 +145,8 @@
                 <p class="flex-fill p-1 ps-2 m-0 text-start">Tile set</p>
             </button>
             <button data-command="assemblyImport" data-auto-event="click"
-                class="btn btn-ui btn-outline-secondary border border-start border-0 rounded-end" title="Import tiles from assembly code.">
+                class="btn btn-ui btn-outline-secondary border border-start border-0 rounded-end"
+                title="Import tiles from assembly code.">
                 <i class="bi bi-code"></i>
             </button>
         </div>

--- a/wwwroot/modules/util/templateUtil.js
+++ b/wwwroot/modules/util/templateUtil.js
@@ -188,6 +188,7 @@ export default class TemplateUtil {
  * @argument {HTMLElement} sender - Element that initiated the event.
  * @argument {string} eventType - Type of event that occurred.
  * @argument {string} command - Associated command.
+ * @argument {Event} event - Associated command.
  * @exports
  */
 


### PR DESCRIPTION
Added a sort option to the drop list in the palette editor and tile manager.

![image](https://github.com/NicDoesCode/SMSGFX/assets/9479714/3439d337-ba96-41f2-ab01-b62a43f6c385)
![image](https://github.com/NicDoesCode/SMSGFX/assets/9479714/084ca8f0-ffe6-41c1-86bf-fbda1dca703a)
