### PR TITLE
Implement click to reorder

### DIFF
--- a/wwwroot/assets/css/styles.css
+++ b/wwwroot/assets/css/styles.css
@@ -1,7 +1,7 @@
 body.sms-app .sms-loading {
-    background: radial-gradient(circle, var(--bs-dark-bg-subtle) 15%, rgba(0, 0, 0, 0) 50%); 
+    background: radial-gradient(circle, var(--bs-dark-bg-subtle) 15%, rgba(0, 0, 0, 0) 50%);
     transition: opacity 0.25s;
-    top: 0; 
+    top: 0;
     bottom: 0;
     left: 0;
     right: 0;
@@ -319,41 +319,57 @@ button:disabled img {
     padding-bottom: 4px;
 }
 
-[data-bs-theme=dark] .sms-accordion-list button.sms-accordion-item {
+/* Styles for drag and drop on the palette select list */
+
+.sms-accordion-list [data-list-item] {
+    transition: border-width 100ms linear;
+}
+
+.sms-accordion-list [data-list-item].list-insert-top {
+    border-top: 5px solid var(--bs-primary) !important;
+}
+
+.sms-accordion-list [data-list-item].list-insert-bottom,
+.sms-accordion-list [data-list-item]:last-of-type.list-insert-bottom {
+    border-bottom: 5px solid var(--bs-primary) !important;
+}
+
+[data-bs-theme=dark] .sms-accordion-list [data-list-item] button.sms-accordion-item {
     background-color: var(--bs-dark-bg-subtle);
 }
 
-.sms-accordion-list button.sms-accordion-item.active {
+.sms-accordion-list [data-list-item] button.sms-accordion-item.active {
     color: var(--bs-dark-text);
     background-color: var(--bs-secondary-bg);
     border-bottom: none !important;
     text-shadow: 0 0 3px #FFFFFF;
 }
 
-[data-bs-theme=dark] .sms-accordion-list button.sms-accordion-item.active {
+[data-bs-theme=dark] .sms-accordion-list [data-list-item] button.sms-accordion-item.active {
     color: var(--bs-light-text-emphasis);
     text-shadow: 0 0 3px #000000;
 }
 
-.sms-accordion-list button.sms-accordion-item .icon-expanded {
+.sms-accordion-list [data-list-item] button.sms-accordion-item .icon-expanded {
     display: none;
 }
 
-.sms-accordion-list button.sms-accordion-item.active .icon-expand {
+.sms-accordion-list [data-list-item] button.sms-accordion-item.active .icon-expand {
     display: none;
 }
 
-.sms-accordion-list button.sms-accordion-item.active.hidden-when-active,
-.sms-accordion-list button.sms-accordion-item.active .hidden-when-active {
+.sms-accordion-list [data-list-item] button.sms-accordion-item.active.hidden-when-active,
+.sms-accordion-list [data-list-item] button.sms-accordion-item.active .hidden-when-active {
     display: none !important;
 }
 
-.sms-accordion-list.sms-accordion-list-bottom button.sms-accordion-item {
-    border-top: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
+.sms-accordion-list [data-list-item]:last-of-type {
     border-bottom: none !important;
+    border-bottom-left-radius: var(--bs-card-border-radius);
+    border-bottom-right-radius: var(--bs-card-border-radius);
 }
 
-.sms-accordion-list.sms-accordion-list-bottom button.sms-accordion-item:last-of-type {
+.sms-accordion-list [data-list-item]:last-of-type button {
     border-bottom-left-radius: var(--bs-card-border-radius);
     border-bottom-right-radius: var(--bs-card-border-radius);
 }

--- a/wwwroot/assets/css/styles.css
+++ b/wwwroot/assets/css/styles.css
@@ -334,8 +334,20 @@ button:disabled img {
     border-bottom: 5px solid var(--bs-primary) !important;
 }
 
+.sms-accordion-list [data-list-item] button {
+    transition: background-color 100ms linear;
+}
+
+.sms-accordion-list [data-list-item] button:hover.sms-accordion-item {
+    background-color: var(--bs-dark-bg-subtle);
+}
+
 [data-bs-theme=dark] .sms-accordion-list [data-list-item] button.sms-accordion-item {
     background-color: var(--bs-dark-bg-subtle);
+}
+
+[data-bs-theme=dark] .sms-accordion-list [data-list-item] button:hover.sms-accordion-item {
+    background-color: var(--bs-black);
 }
 
 .sms-accordion-list [data-list-item] button.sms-accordion-item.active {

--- a/wwwroot/modules/engine/helpers/stackedListReorderHelper.js
+++ b/wwwroot/modules/engine/helpers/stackedListReorderHelper.js
@@ -161,8 +161,6 @@ export default class StackedListReorderHelper {
         const nearTop = (ev.clientY - rect.top) < 15;
         const nearBottom = (rect.bottom - ev.clientY) < 15;
 
-        console.log(`nearbottom ? ${nearBottom}, ${rect.bottom}-${ev.clientY}=${(rect.bottom - ev.clientY)}`);
-
         if (!nearTop && !nearBottom) return;
 
         this.#targetItemId = itemId;

--- a/wwwroot/modules/engine/helpers/stackedListReorderHelper.js
+++ b/wwwroot/modules/engine/helpers/stackedListReorderHelper.js
@@ -1,0 +1,250 @@
+import EventDispatcher from "../../components/eventDispatcher.js";
+import { DropPosition } from "../../types.js";
+
+
+const EVENT_OnCommand = 'EVENT_OnCommand';
+
+const commands = {
+    reorder: 'reorder'
+}
+
+
+/**
+ * Manages the list re-ordering functions.
+ */
+export default class StackedListReorderHelper {
+
+
+    /**
+     * Gets a list of commands that this object can invoke.
+     */
+    static get Commands() {
+        return commands;
+    }
+
+
+    /** @type {HTMLElement} */
+    #element;
+    /** @type {EventDispatcher} */
+    #dispatcher;
+    /** @type {boolean} */
+    #listMouseDown = false;
+    /** @type {string?} */
+    #originItemId = null;
+    /** @type {number?} */
+    #targetItemId = null;
+    /** @type {string?} */
+    #targetItemPosition = null;
+    /** @type {string[]} */
+    #itemIdList;
+    /** @type {string} */
+    #selectedItemId;
+    /** @type {string} */
+    #itemIdAttributeName = 'data-item-id';
+
+
+    /**
+     * @param {HTMLElement} element - HTML element that contains the stacked list that can be re-ordered.
+     * @param {string} [itemIdAttributeNameOverride] - Overrides the attribute name that has the item ID.
+     */
+    constructor(element, itemIdAttributeNameOverride) {
+
+        this.#element = element;
+        this.#dispatcher = new EventDispatcher();
+
+        if (typeof itemIdAttributeNameOverride === 'string' && itemIdAttributeNameOverride !== null) {
+            this.#itemIdAttributeName = itemIdAttributeNameOverride;
+        }
+
+        document.addEventListener('blur', () => this.#resetTrackingVariables());
+        document.addEventListener('mouseup', () => this.#resetTrackingVariables());
+        this.#wireUpListContainer(this.#element);
+    }
+
+
+    /**
+     * Registers a handler for a command.
+     * @param {StackedListReorderHelperCommandCallback} callback - Callback that will receive the command.
+     */
+    addHandlerOnCommand(callback) {
+        this.#dispatcher.on(EVENT_OnCommand, callback);
+    }
+
+
+    #resetTrackingVariables() {
+        this.#listMouseDown = false;
+        this.#originItemId = null;
+        this.#targetItemId = null;
+        this.#targetItemPosition = null;
+    }
+
+
+    /**
+     * @param {HTMLElement} listContainer 
+     */
+    #wireUpListContainer(listContainer) {
+        if (!listContainer?.addEventListener) return;
+
+        listContainer.addEventListener('mouseup', (ev) => this.#handleListMouseUp(ev, listContainer));
+        listContainer.addEventListener('mouseleave', (ev) => this.#handleListMouseLeave(ev, listContainer));
+        listContainer.addEventListener('mousemove', (ev) => this.#handleListMouseMove(ev, listContainer));
+    }
+
+    wireUpItems() {
+        this.#itemIdList = [];
+        this.#element.querySelectorAll(`[data-list-item]`).forEach((/** @type {HTMLElement} */ itemContainer, index) => {
+
+            const itemId = itemContainer.getAttribute(this.#itemIdAttributeName);
+            this.#itemIdList.push(itemId);
+
+            itemContainer.addEventListener('mousedown', (ev) => {
+                const itemRect = itemContainer.getBoundingClientRect();
+                const pixelsFromTop = ev.clientY - itemRect.top;
+                if (itemRect.height < 50 || pixelsFromTop < 30) {
+                    this.#listMouseDown = true;
+                    this.#originItemId = itemId;
+                }
+            });
+
+        });
+    }
+
+
+    /**
+     * @param {MouseEvent} ev 
+     * @param {HTMLElement} listContainer 
+     */
+    #handleListMouseUp(ev, listContainer) {
+        if (this.#targetItemId === null || this.#originItemId === null) return;
+        if (this.#targetItemId === this.#originItemId) return;
+
+        /** @type {StackedListReorderHelperCommandEventArgs} */
+        const args = {
+            command: commands.reorder,
+            originItemId: this.#originItemId,
+            targetItemId: this.#targetItemId,
+            targetItemPosition: this.#targetItemPosition
+        };
+        this.#dispatcher.dispatch(EVENT_OnCommand, args);
+    }
+
+    /**
+     * @param {MouseEvent} ev 
+     * @param {HTMLElement} listContainer 
+     */
+    #handleListMouseLeave(ev, listContainer) {
+        const rect = listContainer.getBoundingClientRect();
+        if (ev.clientX <= rect.left || ev.clientX >= rect.right || ev.clientY <= rect.top || ev.clientY >= rect.bottom) {
+            listContainer.querySelectorAll(`[data-list-item]`).forEach((container) => {
+                container.classList.remove('list-insert-top', 'list-insert-bottom');
+            });
+        }
+    }
+
+    /**
+     * @param {MouseEvent} ev 
+     * @param {HTMLElement} listContainer 
+     */
+    #handleListMouseMove(ev, listContainer) {
+        if (!this.#listMouseDown) return;
+
+        this.#targetItemId = null;
+        this.#targetItemPosition = null;
+
+        // If the container was found, do our calculations to work out next item ID etc
+        const itemContainer = this.#crawlParentsToFindItemContainer(ev.target);
+        if (!itemContainer) return;
+
+        const itemId = itemContainer.getAttribute(this.#itemIdAttributeName);
+
+        const rect = itemContainer.getBoundingClientRect();
+        const nearTop = (ev.clientY - rect.top) < 15;
+        const nearBottom = (rect.bottom - ev.clientY) < 15;
+
+        console.log(`nearbottom ? ${nearBottom}, ${rect.bottom}-${ev.clientY}=${(rect.bottom - ev.clientY)}`);
+
+        if (!nearTop && !nearBottom) return;
+
+        this.#targetItemId = itemId;
+        this.#targetItemPosition = nearTop ? DropPosition.before : nearBottom ? DropPosition.after : null;
+
+        this.#setDropIndicatorCSS(this.#targetItemId, this.#targetItemPosition);
+    }
+
+    /**
+     * @param {HTMLElement} startingElement 
+     */
+    #crawlParentsToFindItemContainer(startingElement) {
+        let result = startingElement;
+        while (result && result !== this.#element) {
+            if (result.hasAttribute('data-list-item')) return result;
+            result = result.parentElement;
+        }
+        return null;
+    }
+
+    /**
+     * @param {string} itemId 
+     * @param {string} itemPosition - Either 'before' or 'after'.
+     */
+    #setDropIndicatorCSS(itemId, itemPosition) {
+
+        /** @type {HTMLElement} */
+        let itemContainerWithTopHighlighted = null;
+        /** @type {HTMLElement} */
+        let itemContainerWithBottomHighlighted = null;
+
+        const itemIndex = this.#itemIdList.indexOf(itemId);
+
+        if (itemPosition === DropPosition.before) {
+            const itemIdBefore = (itemIndex - 1) >= 0 ? this.#itemIdList[itemIndex - 1] : null;
+            itemContainerWithBottomHighlighted = this.#getListItemContainer(itemIdBefore);
+            itemContainerWithTopHighlighted = this.#getListItemContainer(itemId);
+        } else if (itemPosition === DropPosition.after) {
+            const itemIdAfter = (itemIndex + 1) < this.#itemIdList.length ? this.#itemIdList[itemIndex + 1] : null;
+            itemContainerWithTopHighlighted = this.#getListItemContainer(itemIdAfter);
+            itemContainerWithBottomHighlighted = this.#getListItemContainer(itemId);
+        }
+
+        itemContainerWithTopHighlighted?.classList.add('list-insert-top');
+        itemContainerWithBottomHighlighted?.classList.add('list-insert-bottom');
+
+        // Reset CSS on all other containers
+        this.#element.querySelectorAll(`[data-list-item]`).forEach((itemContainerToReset) => {
+            if (itemContainerToReset !== itemContainerWithTopHighlighted) {
+                itemContainerToReset.classList.remove('list-insert-top');
+            }
+            if (itemContainerToReset !== itemContainerWithBottomHighlighted) {
+                itemContainerToReset.classList.remove('list-insert-bottom');
+            }
+        });
+    }
+
+    /**
+     * @param {string?} itemId 
+     * @returns {HTMLElement}
+     */
+    #getListItemContainer(itemId) {
+        if (!itemId) return null;
+        return this.#element.querySelector(`[data-list-item][${this.#itemIdAttributeName}=${CSS.escape(itemId)}]`);
+    }
+
+
+}
+
+
+/**
+ * Callback for when a command event is invoked.
+ * @callback StackedListReorderHelperCommandCallback
+ * @param {StackedListReorderHelperCommandEventArgs} args - Arguments.
+ * @exports
+ */
+/**
+ * Arguments for a command event.
+ * @typedef {Object} StackedListReorderHelperCommandEventArgs
+ * @property {string} command - The command being invoked.
+ * @property {string?} originItemId - Unique ID of the item that is to be moved.
+ * @property {string?} targetItemId - Unique ID of the item that that the origin item is to be moved beside.
+ * @property {string?} targetItemPosition - Either 'before' or 'after', indicates whether the origin item is to be placed before or after the target item.
+ * @exports
+ */

--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -1141,6 +1141,10 @@ function handlePaletteEditorOnCommand(args) {
             }
             break;
 
+        case PaletteEditor.Commands.paletteChangeIndex:
+            paletteChangeIndexInList(args.paletteId, args.paletteIndex);
+            break;
+
         case PaletteEditor.Commands.paletteNew:
             paletteNew();
             break;
@@ -2615,6 +2619,11 @@ function getTileMapContextToolbarVisibleToolstrips(tool) {
 
 function displaySelectedProject() {
     if (getProject()) {
+        paletteNew();
+        if (getPaletteList().length === 0) {
+            const newPalette = PaletteFactory.createNewStandardColourPalette('New palette', getDefaultPaletteSystemType());
+            getPaletteList().addPalette(newPalette);
+        }
         formatForProject();
     } else {
         formatForNoProject();
@@ -3662,6 +3671,32 @@ function selectTileIndexIfNotSelected(tileIndex) {
             }
         });
     }
+}
+
+/**
+ * Change the palette index in the palette list.
+ * @argument {string} paletteId
+ * @argument {number} newIndex
+ */
+function paletteChangeIndexInList(paletteId, newIndex) {
+    const palette = getPaletteList().getPaletteById(paletteId);
+    let palettes = getPaletteList().getPalettes();
+    const currentIndex = getPaletteList().indexOf(paletteId);
+
+    if (currentIndex === newIndex) {
+        return;
+    } else if (currentIndex > newIndex) {
+        palettes = palettes.splice(currentIndex, 1);
+        palettes = palettes.slice(0, newIndex).concat([palette]).slice(newIndex + 1);
+    } else if (currentIndex < newIndex) {
+
+    }
+
+    addUndoState();
+    getPaletteList().setPalettes(palettes);
+    state.saveToLocalStorage();
+    updatePaletteLists({ skipTileEditor: true });
+
 }
 
 /**

--- a/wwwroot/modules/models/palette.js
+++ b/wwwroot/modules/models/palette.js
@@ -84,12 +84,24 @@ export default class Palette {
     /**
      * Gets the colour at a given index.
      * @param {number} index - Index of the colour to get.
+     * @throws Index is out of range.
      * @returns {PaletteColour}
      */
     getColour(index) {
         if (index >= 0 && index < this.#colours.length) {
             return this.#colours[index];
         } else throw new Error('Colour index was out of range.');
+    }
+
+    /**
+     * Gets the colour at a given index, or null if out of range.
+     * @param {number} index - Index of the colour to get.
+     * @returns {PaletteColour?}
+     */
+    getColourByIndex(index) {
+        if (index >= 0 && index < this.#colours.length) {
+            return this.#colours[index];
+        } else return null;
     }
 
     /**

--- a/wwwroot/modules/models/paletteList.js
+++ b/wwwroot/modules/models/paletteList.js
@@ -77,8 +77,8 @@ export default class PaletteList {
     }
 
     /**
-     * Gets an item by ID.
-     * @param {string} paletteId - Unique Palette ID to fetch.
+     * Gets the index of an item in the list by ID.
+     * @param {string} paletteId - Unique Palette ID to get the index of.
      * @returns {number}
      */
     indexOf(paletteId) {

--- a/wwwroot/modules/models/paletteList.js
+++ b/wwwroot/modules/models/paletteList.js
@@ -52,6 +52,7 @@ export default class PaletteList {
     /**
      * Gets an item by index.
      * @param {number} index - Index of the item to get.
+     * @throws Index is out of range.
      * @returns {Palette}
      */
     getPalette(index) {
@@ -59,6 +60,19 @@ export default class PaletteList {
             return this.#palettes[index];
         } else {
             throw new Error('Index out of range.');
+        }
+    }
+
+    /**
+     * Gets an item by index, or null if out of range.
+     * @param {number} index - Index of the item to get.
+     * @returns {Palette?}
+     */
+    getPaletteByIndex(index) {
+        if (index >= 0 && index < this.#palettes.length) {
+            return this.#palettes[index];
+        } else {
+            return null;
         }
     }
 

--- a/wwwroot/modules/models/projectList.js
+++ b/wwwroot/modules/models/projectList.js
@@ -65,6 +65,7 @@ export default class ProjectList {
     /**
      * Gets an item by index.
      * @param {number} index - Index of the item to get.
+     * @throws Index is out of range.
      * @returns {Project}
      */
     getProject(index) {
@@ -72,6 +73,19 @@ export default class ProjectList {
             return this.#projects[index];
         } else {
             throw new Error('Index out of range.');
+        }
+    }
+
+    /**
+     * Gets an item by index, or null if out of range.
+     * @param {number} index - Index of the item to get.
+     * @returns {Project?}
+     */
+    getProjectByIndex(index) {
+        if (index >= 0 && index < this.#projects.length) {
+            return this.#projects[index];
+        } else {
+            return null;
         }
     }
 

--- a/wwwroot/modules/models/tileMap.js
+++ b/wwwroot/modules/models/tileMap.js
@@ -146,9 +146,23 @@ export default class TileMap extends TileGridProvider {
 
 
     /**
-     * Returns a tile map tile by index.
-     * @param {number} index - Index of the tile to return.
-     * @returns {TileMapTile | null}
+     * Gets an item by index.
+     * @param {number} index - Index of the item to get.
+     * @throws Index is out of range.
+     * @returns {TileMapTile}
+     */
+    getTile(index) {
+        if (index >= 0 && index < this.#tiles.length) {
+            return this.#tiles[index];
+        } else {
+            throw new Error('Index out of range.');
+        }
+    }
+
+    /**
+     * Gets an item by index, or null if out of range.
+     * @param {number} index - Index of the item to get.
+     * @returns {TileMapTile?}
      */
     getTileByIndex(index) {
         if (index >= 0 && index <= this.tileCount) {
@@ -349,9 +363,22 @@ export default class TileMap extends TileGridProvider {
     /**
      * Gets the ID of the palette associated with a given index.
      * @param {number} index - Index of the palette ID to return.
+     * @throws Index out of range.
      * @returns {string?}
      */
     getPalette(index) {
+        if (index < 0 || index >= this.#paletteIds.length) {
+            throw new Error('Index out of range.');
+        }
+        return this.#paletteIds[index];
+    }
+
+    /**
+     * Gets the ID of the palette associated with a given index, or null if index out of range.
+     * @param {number} index - Index of the palette ID to return.
+     * @returns {string?}
+     */
+    getPaletteByIndex(index) {
         if (index < 0 || index >= this.#paletteIds.length) {
             return null;
         }

--- a/wwwroot/modules/models/tileMapList.js
+++ b/wwwroot/modules/models/tileMapList.js
@@ -77,6 +77,7 @@ export default class TileMapList {
     /**
      * Gets an item by index.
      * @param {number} index - Index of the item to get.
+     * @throws Index is out of range.
      * @returns {TileMap}
      */
     getTileMap(index) {
@@ -84,6 +85,19 @@ export default class TileMapList {
             return this.#tileMaps[index];
         } else {
             throw new Error('Index out of range.');
+        }
+    }
+
+    /**
+     * Gets an item by index, or null if out of range.
+     * @param {number} index - Index of the item to get.
+     * @returns {TileMap}
+     */
+    getTileMapByIndex(index) {
+        if (index >= 0 && index < this.#tileMaps.length) {
+            return this.#tileMaps[index];
+        } else {
+            return null;
         }
     }
 

--- a/wwwroot/modules/models/tileMapList.js
+++ b/wwwroot/modules/models/tileMapList.js
@@ -102,6 +102,22 @@ export default class TileMapList {
     }
 
     /**
+     * Gets the index of an item in the list by ID.
+     * @param {string} tileMapId - Unique tile map ID to get the index of.
+     * @returns {number}
+     */
+    indexOf(tileMapId) {
+        if (typeof tileMapId !== 'string') return -1;
+        for (let i = 0; i < this.#tileMaps.length; i++) {
+            if (this.#tileMaps[i].tileMapId === tileMapId) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+
+    /**
      * Adds an item to the list.
      * @param {TileMap|TileMap[]} value - Item or array of items to add.
      */

--- a/wwwroot/modules/models/tileSet.js
+++ b/wwwroot/modules/models/tileSet.js
@@ -159,8 +159,8 @@ export default class TileSet extends TileGridProvider {
     }
 
     /**
-     * Gets a tile from the tile map based on index, returns null if index out of range.
-     * @param {number} index - Index in the tile map of the tile to get.
+     * Gets an item by index, or null if out of range.
+     * @param {number} index - Index of the item to get.
      * @returns {Tile?}
      */
     getTileByIndex(index) {

--- a/wwwroot/modules/types.js
+++ b/wwwroot/modules/types.js
@@ -1,4 +1,8 @@
 export const Types = {};
+export const DropPosition = {
+    before: 'before',
+    after: 'after'
+}
 
 /**
  * @typedef {Object} SampleProject

--- a/wwwroot/modules/ui/components/paletteListing.js
+++ b/wwwroot/modules/ui/components/paletteListing.js
@@ -100,8 +100,9 @@ export default class PaletteListing extends ComponentBase {
      * @param {Palette[]} palettes
      */
     #displayPalettes(palettes) {
-        const renderList = palettes.map((p) => {
+        const renderList = palettes.map((p, index) => {
             return {
+                index: index,
                 paletteId: p.paletteId,
                 title: p.title,
                 system: p.system

--- a/wwwroot/modules/ui/paletteEditor.html
+++ b/wwwroot/modules/ui/paletteEditor.html
@@ -161,21 +161,21 @@
     <!-- End: Palette editor context menu -->
 
     <style data-css-scope="global">
+        /* Styles for drag and drop on the palette select list */
+
         .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container] {
             transition: border-width 100ms linear;
         }
 
         .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container].highlight-top {
-            border-top: 10px solid lime !important;
+            border-top: 10px solid var(--bs-primary);
         }
 
         .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container].highlight-bottom {
-            border-bottom: 10px solid lime !important;
+            border-bottom: 10px solid var(--bs-primary);
         }
 
-
-
-
+        /* Palette properties panel */
 
         .sms-palette-editor .sms-palette-properties {
             background: linear-gradient(180deg, var(--bs-secondary-bg) 0%, rgba(33, 37, 41, 0) 40%);

--- a/wwwroot/modules/ui/paletteEditor.html
+++ b/wwwroot/modules/ui/paletteEditor.html
@@ -28,7 +28,7 @@
     </div>
     <!-- End: Palette editor : header -->
 
-    <div class="overflow-hidden overflow-y-auto">
+    <div data-smsgfx-id="palette-list-container" class="overflow-hidden overflow-y-auto">
 
         <div data-smsgfx-id="palette-list-top" data-smsgfx-component-id="palette-list"
             class="sms-accordion-list sms-accordion-list-top sms-palette-select-list card-body p-0">
@@ -159,6 +159,25 @@
     <!-- End: Palette editor context menu -->
 
     <style data-css-scope="global">
+        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-properties],
+        .sms-palette-editor .sms-palette-select-list button[data-command=paletteSelect] {
+            transition: border-width 100ms linear;
+        }
+
+        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-properties].highlight-top,
+        .sms-palette-editor .sms-palette-select-list button[data-command=paletteSelect].highlight-top {
+            border-top: 10px solid lime !important;
+        }
+
+        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-properties].highlight-bottom,
+        .sms-palette-editor .sms-palette-select-list button[data-command=paletteSelect].highlight-bottom {
+            border-bottom: 10px solid lime !important;
+        }
+
+
+
+
+
         .sms-palette-editor .sms-palette-properties {
             background: linear-gradient(180deg, var(--bs-secondary-bg) 0%, rgba(33, 37, 41, 0) 40%);
         }

--- a/wwwroot/modules/ui/paletteEditor.html
+++ b/wwwroot/modules/ui/paletteEditor.html
@@ -30,15 +30,16 @@
 
     <div data-smsgfx-id="palette-list-container" class="overflow-hidden overflow-y-auto">
 
-        <div data-smsgfx-id="palette-list-top" data-smsgfx-component-id="palette-list"
+        <div data-smsgfx-id="palette-list" data-smsgfx-component-id="palette-list" data-list-item-container
             class="sms-accordion-list sms-accordion-list-top sms-palette-select-list card-body p-0">
             <template>
                 <script data-smsgfx-template-id="item-template" type="text/x-handlebars-template">
                     <div class="list-group rounded-0 border border-0">
                         {{#each this}}
-                        <div data-smsgfx-id="palette-item-container" data-palette-id="{{paletteId}}" data-palette-index="{{index}}">
+                        <div data-list-item data-smsgfx-id="palette-item-container" data-palette-id="{{paletteId}}" data-palette-index="{{index}}"
+                            class="border border-0 border-bottom p-0 m-0">
                             <button data-command="paletteSelect" data-palette-id="{{paletteId}}" data-palette-index="{{index}}"
-                                class="sms-accordion-item list-group-item hidden-when-active border border-0 border-bottom text-start fw-bold d-flex flex-row w-100 p-0 m-0"
+                                class="sms-accordion-item hidden-when-active text-start fw-bold d-flex flex-row w-100 p-0 m-0 border border-0"
                                 title="{{title}}">
                                 <label class="p-2 fw-bold text-body-emphasis text-start overflow-hidden text-nowrap flex-shrink w-100">{{title}}</label>
                                 <span class="icon-expand p-2"><i class="bi bi-caret-down-fill"></i></span>
@@ -147,12 +148,6 @@
             </div>
         </div>
 
-        <div data-smsgfx-id="palette-list-bottom"
-            class="sms-accordion-list sms-accordion-list-bottom sms-palette-select-list card-body p-0">
-            <div class="list-group rounded-0 border border-0">
-            </div>
-        </div>
-
     </div>
 
     <!-- Palette editor context menu -->
@@ -161,23 +156,7 @@
     <!-- End: Palette editor context menu -->
 
     <style data-css-scope="global">
-        /* Styles for drag and drop on the palette select list */
-
-        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container] {
-            transition: border-width 100ms linear;
-        }
-
-        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container].highlight-top {
-            border-top: 10px solid var(--bs-primary);
-        }
-
-        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container].highlight-bottom {
-            border-bottom: 10px solid var(--bs-primary);
-        }
-
-        /* Palette properties panel */
-
-        .sms-palette-editor .sms-palette-properties {
+        .sms-palette-editor [data-list-item] .sms-palette-properties {
             background: linear-gradient(180deg, var(--bs-secondary-bg) 0%, rgba(33, 37, 41, 0) 40%);
         }
 

--- a/wwwroot/modules/ui/paletteEditor.html
+++ b/wwwroot/modules/ui/paletteEditor.html
@@ -36,12 +36,14 @@
                 <script data-smsgfx-template-id="item-template" type="text/x-handlebars-template">
                     <div class="list-group rounded-0 border border-0">
                         {{#each this}}
-                        <button data-command="paletteSelect" data-palette-id="{{paletteId}}" 
-                            class="sms-accordion-item list-group-item hidden-when-active border border-0 border-bottom text-start fw-bold d-flex flex-row w-100 p-0 m-0"
-                            title="{{title}}">
-                            <label class="p-2 fw-bold text-body-emphasis text-start overflow-hidden text-nowrap flex-shrink w-100">{{title}}</label>
-                            <span class="icon-expand p-2"><i class="bi bi-caret-down-fill"></i></span>
-                        </button>
+                        <div data-smsgfx-id="palette-item-container" data-palette-id="{{paletteId}}" data-palette-index="{{index}}">
+                            <button data-command="paletteSelect" data-palette-id="{{paletteId}}" data-palette-index="{{index}}"
+                                class="sms-accordion-item list-group-item hidden-when-active border border-0 border-bottom text-start fw-bold d-flex flex-row w-100 p-0 m-0"
+                                title="{{title}}">
+                                <label class="p-2 fw-bold text-body-emphasis text-start overflow-hidden text-nowrap flex-shrink w-100">{{title}}</label>
+                                <span class="icon-expand p-2"><i class="bi bi-caret-down-fill"></i></span>
+                            </button>
+                        </div>
                         {{/each}}
                     </div>
                 </script>
@@ -159,18 +161,15 @@
     <!-- End: Palette editor context menu -->
 
     <style data-css-scope="global">
-        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-properties],
-        .sms-palette-editor .sms-palette-select-list button[data-command=paletteSelect] {
+        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container] {
             transition: border-width 100ms linear;
         }
 
-        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-properties].highlight-top,
-        .sms-palette-editor .sms-palette-select-list button[data-command=paletteSelect].highlight-top {
+        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container].highlight-top {
             border-top: 10px solid lime !important;
         }
 
-        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-properties].highlight-bottom,
-        .sms-palette-editor .sms-palette-select-list button[data-command=paletteSelect].highlight-bottom {
+        .sms-palette-editor .sms-palette-select-list div[data-smsgfx-id=palette-item-container].highlight-bottom {
             border-bottom: 10px solid lime !important;
         }
 

--- a/wwwroot/modules/ui/paletteEditor.js
+++ b/wwwroot/modules/ui/paletteEditor.js
@@ -249,6 +249,7 @@ export default class PaletteEditor extends ComponentBase {
         });
 
         document.addEventListener('mouseup', (e) => {
+            this.#paletteListMouseDown = false;
             this.#paletteListHoverPaletteIndex = null;
             this.#paletteListHoverPaletteId = null;
         });

--- a/wwwroot/modules/ui/paletteEditor.js
+++ b/wwwroot/modules/ui/paletteEditor.js
@@ -29,7 +29,7 @@ const commands = {
 }
 
 export const sortFields = {
-    system: 'system', 
+    system: 'system',
     title: 'title'
 }
 
@@ -160,6 +160,48 @@ export default class PaletteEditor extends ComponentBase {
                 this.#paletteListComponent = component;
                 this.#paletteListComponent.addHandlerOnCommand((args) => this.#handlePaletteListOnCommand(args));
             });
+
+        this.#element.querySelectorAll(`[data-smsgfx-id=palette-list-container]`).forEach((containerElm) => {
+            console.log('container', containerElm);
+            containerElm.addEventListener('mousemove', (/** @type {MouseEvent} */ e) => {
+
+                /** @type{HTMLDivElement} */
+                let pal = e.target.getAttribute('data-smsgfx-id') === 'palette-properties' ? e.target : null;
+                if (!pal) pal = e.target?.parentElement?.getAttribute('data-smsgfx-id') === 'palette-properties' ? e.target.parentElement : null;
+
+                // e.target = `[data-smsgfx-id=palette-properties]`;
+                console.log(pal);
+
+                // Get palette button
+                /** @type{HTMLButtonElement} */
+                let btn = e.target?.getAttribute('data-command') === commands.paletteSelect ? e.target : null;
+                if (!btn) btn = e.target?.parentElement?.getAttribute('data-command') === commands.paletteSelect ? e.target.parentElement : null;
+                if (btn) {
+                    containerElm.querySelectorAll(`button[data-command=${commands.paletteSelect}]`).forEach((btn2) => {
+                        if (btn === btn2) {
+                            console.log(`equal`);
+                            if (e.offsetY < 10) {
+                                console.log(`Highlight top`);
+                                btn.classList.add('highlight-top');
+                            } else if (e.offsetY > (btn.clientHeight - 10)) {
+                                btn.classList.add('highlight-bottom');
+                            } else {
+                                // btn.classList.remove('highlight-top', 'highlight-bottom');
+                                btn.classList.remove('highlight-top', 'highlight-bottom');
+                            }
+                        } else {
+                            btn2.classList.remove('highlight-top', 'highlight-bottom');
+                        }
+                    });
+                }
+                // if (e.target.hasAttribute('data-palette-id')) {
+                //     console.log(`Hover: ${e.target.getAttribute('data-palette-id')}`);
+                // }
+                // if (e.target.parentElement.hasAttribute('data-palette-id')) {
+                //     console.log(`Hover parent: ${e.target.parentElement.getAttribute('data-palette-id')}`);
+                // }
+            });
+        });
     }
 
 
@@ -258,6 +300,7 @@ export default class PaletteEditor extends ComponentBase {
                 selectedPaletteId: this.#selectedPaletteId
             });
             this.#shufflePaletteList();
+            // this.#createDragDropTargets();
             const palette = this.#paletteList.getPaletteById(this.#selectedPaletteId);
             if (palette) {
                 this.#setPalette(palette);
@@ -490,6 +533,27 @@ export default class PaletteEditor extends ComponentBase {
                 });
             }
         }
+    }
+
+    #createDragDropTargets() {
+        const listTop = this.#element.querySelector('[data-smsgfx-id=palette-list-top] div.list-group');
+        const listBottom = this.#element.querySelector('[data-smsgfx-id=palette-list-bottom] div.list-group');
+
+        const createDropTarget = () => {
+            const target = document.createElement('div');
+            target.classList.add('sms-drop-target');
+            target.setAttribute('data-drop-target', '');
+            return target;
+        };
+
+        // Create the drop targets
+        [listTop, listBottom].forEach((listElm) => {
+            listElm.querySelectorAll('[data-drop-target]').forEach((dropElm) => dropElm.remove());
+            listElm.querySelectorAll(`button[data-command=${commands.paletteSelect}]`).forEach((btn) => {
+                btn.before(createDropTarget());
+            });
+        })
+        listBottom.appendChild(createDropTarget());
     }
 
     /**

--- a/wwwroot/modules/ui/tileManager.html
+++ b/wwwroot/modules/ui/tileManager.html
@@ -17,34 +17,38 @@
                 <li>
                     <hr class="dropdown-divider">
                 </li>
-                <li><a data-command="tileSetSelect" data-auto-event="click" class="dropdown-item"
-                    href="#">Edit tile set</a></li>
-            <li>
-                <hr class="dropdown-divider">
-            </li>
-        </ul>
+                <li><a data-command="tileSetSelect" data-auto-event="click" class="dropdown-item" href="#">Edit tile
+                        set</a></li>
+                <li>
+                    <hr class="dropdown-divider">
+                </li>
+            </ul>
         </div>
 
-        <div class="overflow-hidden overflow-y-auto">
+        <div data-smsgfx-id="tile-map-list-container" class="overflow-hidden overflow-y-auto">
 
-            <div data-smsgfx-id="tile-map-list-top" data-smsgfx-component-id="tile-map-listing"
+            <div data-smsgfx-id="tile-map-list" data-smsgfx-component-id="tile-map-listing" data-list-item-container
                 class="sms-accordion-list sms-accordion-list-top sms-tile-map-select-list card-body p-0">
                 <template>
                     <script data-smsgfx-template-id="item-template" type="text/x-handlebars-template">
                     <div class="list-group rounded-0 border border-0">
                         {{#each this}}
-                        <button data-command="tileMapSelect" data-auto-event="click" data-tile-map-id="{{tileMapId}}" 
-                            class="sms-accordion-item list-group-item hidden-when-active border border-0 border-bottom text-start fw-bold d-flex flex-row w-100 p-0 m-0">
-                            <label class="p-2 fw-bold text-body-emphasis text-start overflow-hidden text-nowrap flex-shrink w-100">{{title}}</label>
-                            <span class="icon-expand p-2"><i class="bi bi-caret-down-fill"></i></span>
-                        </button>
+                        <div data-list-item data-smsgfx-id="tile-map-item-container" data-tile-map-id="{{tileMapId}}"
+                            class="border border-0 border-bottom p-0 m-0">
+                            <button data-command="tileMapSelect" data-auto-event="click" data-tile-map-id="{{tileMapId}}" 
+                                class="sms-accordion-item list-group-item hidden-when-active text-start fw-bold d-flex flex-row w-100 p-0 m-0 border border-0">
+                                <label class="p-2 fw-bold text-body-emphasis text-start overflow-hidden text-nowrap flex-shrink w-100">{{title}}</label>
+                                <span class="icon-expand p-2"><i class="bi bi-caret-down-fill"></i></span>
+                            </button>
+                        </div>
                         {{/each}}
                     </div>
                 </script>
                 </template>
             </div>
 
-            <div class="sms-tile-map-properties card-body p-2 pt-0 visually-hidden" data-smsgfx-id="tileMapProperties">
+            <div class="sms-tile-map-properties card-body p-2 pt-0 visually-hidden"
+                data-smsgfx-id="tile-map-properties">
                 <div class="row mb-2">
                     <div class="col">
                         <button data-smsgfx-id="editTileMapTitle"
@@ -128,19 +132,13 @@
                 </div>
             </div>
 
-            <div data-smsgfx-id="tile-map-list-bottom"
-                class="sms-accordion-list sms-accordion-list-bottom sms-tile-map-select-list card-body p-0">
-                <div class="list-group rounded-0 border border-0">
-                </div>
-            </div>
-
         </div>
 
     </div>
 
     <div class="sms-tile-set sms-toolbox card mb-2" data-smsgfx-toolbox-item>
         <div class="card-header sms-card-toolbar p-0 d-flex">
-            <button data-command="tileSetSelect"
+            <button data-auto-event="click" data-command="tileSetSelect"
                 class="btn btn-ui btn-outline-secondary border border-0 p-0 m-0 flex-fill rounded-start">
                 <p class="flex-fill p-1 ps-2 m-0 text-start">Tile set</p>
             </button>
@@ -151,7 +149,8 @@
             </button>
         </div>
         <div class="card-body p-0">
-            <div class="sms-tile-map-properties card-body p-2 pt-0 visually-hidden" data-smsgfx-id="tileSetProperties">
+            <div class="sms-tile-map-properties card-body p-2 pt-0 visually-hidden"
+                data-smsgfx-id="tile-set-properties">
                 <div class="row mb-0 ps-3 pe-3">
                     <div class="col p-1">
                         <p class="m-0 mb-1">
@@ -211,7 +210,7 @@
             padding-bottom: 4px;
         }
 
-        .sms-tile-manager .sms-tile-map .sms-tile-map-properties {
+        .sms-tile-manager [data-list-item] .sms-tile-map-properties {
             background: linear-gradient(180deg, var(--bs-secondary-bg) 0%, rgba(33, 37, 41, 0) 40%);
         }
 

--- a/wwwroot/modules/ui/tileManager.js
+++ b/wwwroot/modules/ui/tileManager.js
@@ -464,7 +464,7 @@ export default class TileManager extends ComponentBase {
 
         this.#paletteSelectorElement.querySelectorAll('select[data-field=paletteId]').forEach((/** @type {HTMLSelectElement} */ select) => {
             const slotNumber = parseInt(select.getAttribute('data-palette-slot'));
-            const selectedPaletteId = tileMap.getPalette(slotNumber);
+            const selectedPaletteId = tileMap.getPaletteByIndex(slotNumber);
             paletteList.getPalettes().forEach((palette, paletteIndex) => {
                 const option = document.createElement('option');
                 option.value = palette.paletteId;
@@ -494,7 +494,7 @@ export default class TileManager extends ComponentBase {
         /** @type {Palette[]} */
         const renderPalettes = new Array(this.#numberOfPaletteSlots);
         for (let i = 0; i < this.#numberOfPaletteSlots; i++) {
-            const paletteId = tileMap.getPalette(i);
+            const paletteId = tileMap.getPaletteByIndex(i);
             const palette = paletteList.getPaletteById(paletteId);
             if (paletteId && palette) {
                 renderPalettes[i] = PaletteFactory.clone(palette);

--- a/wwwroot/modules/util/tileMapUtil.js
+++ b/wwwroot/modules/util/tileMapUtil.js
@@ -98,7 +98,7 @@ export default class TileMapUtil {
         optimised.tileMapList.getTileMaps().forEach((tileMap) => {
             const capability = tileMap.isSprite ? capabilities.sprite : capabilities.background;
             for (let i = 0; i < capability.totalPaletteSlots; i++) {
-                const palette = paletteList.getPaletteById(tileMap.getPalette(i));
+                const palette = paletteList.getPaletteById(tileMap.getPaletteByIndex(i));
                 if (palette && !optimisedPaletteList.getPaletteById(palette.paletteId)) {
                     optimisedPaletteList.addPalette(palette);
                 }


### PR DESCRIPTION
Implemented click to re-order on the palette and tile map lists.
- Created a single helper class with shared logic.
- Tweaked CSS styles.
- The properties editor in palette and tile map is now physically moved instead of maintaining two lists of items.
- Added some additional useful methods to tile map list.