### PR TITLE
#236: Move render palette list outside of components

### DIFF
--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -1778,6 +1778,8 @@ function handleColourPickerToolboxOnCommand(args) {
  * @param {import('./types.js').ColourInformation} colour
  */
 function paletteSetColourAtIndexWithoutSaving(paletteIndex, colourIndex, colour) {
+    currentProject.nativePalettes = null;
+
     const palette = getPaletteList().getPalette(paletteIndex);
 
     const newColour = PaletteColourFactory.create(colour.r, colour.g, colour.b);
@@ -2533,6 +2535,8 @@ function formatForProject() {
         paletteSlot: instanceState.paletteSlot
     });
 
+    updateTileEditorGridColours();
+
     refreshProjectUI();
 
     instanceState.previousProjectId = getProject().id;
@@ -2637,6 +2641,8 @@ function formatForNoProject() {
         paletteList: null,
         selectedTileMapId: null
     });
+
+    updateTileEditorGridColours();
 }
 
 /**
@@ -4007,8 +4013,6 @@ function changePaletteEditorDisplayNativeColours(displayNative) {
     state.persistentUIState.displayNativeColour = displayNative;
     state.saveToLocalStorage();
 
-    const isGameboyProject = displayNative && getProject().systemType === 'gb';
-    
     paletteEditor.setState({
         paletteList: getRenderPaletteList(),
         displayNative: getUIState().displayNativeColour
@@ -4016,15 +4020,23 @@ function changePaletteEditorDisplayNativeColours(displayNative) {
     tileEditor.setState({
         tileGrid: getTileGrid(),
         tileSet: getTileSet(),
-        paletteList: getRenderPaletteListToSuitTileMapOrTileSetSelection(),
-        pixelGridColour: (isGameboyProject) ? '#98a200' : '#000000',
-        pixelGridOpacity: (isGameboyProject) ? 0.5 : 0.2,
-        tileGridColour: (isGameboyProject) ? '#98a200' : '#000000',
-        tileGridOpacity: (isGameboyProject) ? 1 : 0.4
+        paletteList: getRenderPaletteListToSuitTileMapOrTileSetSelection()
     });
     tileManager.setState({
         paletteList: getRenderPaletteList(),
         palette: getRenderPalette()
+    });
+
+    updateTileEditorGridColours();
+}
+
+function updateTileEditorGridColours() {
+    const isGameboyProject = getUIState().displayNativeColour && getProject().systemType === 'gb';
+    tileEditor.setState({
+        pixelGridColour: (isGameboyProject) ? '#98a200' : '#000000',
+        pixelGridOpacity: (isGameboyProject) ? 0.5 : 0.2,
+        tileGridColour: (isGameboyProject) ? '#98a200' : '#000000',
+        tileGridOpacity: (isGameboyProject) ? 1 : 0.4
     });
 }
 
@@ -4070,7 +4082,8 @@ function swapColourIndex(sourceColourIndex, targetColourIndex) {
         paletteList: getRenderPaletteList()
     });
     tileManager.setState({
-        paletteList: getRenderPaletteList()
+        paletteList: getRenderPaletteList(),
+        palette: getRenderPalette()
     });
 }
 

--- a/wwwroot/modules/main.js
+++ b/wwwroot/modules/main.js
@@ -2642,6 +2642,20 @@ function getTileMapContextToolbarVisibleToolstrips(tool) {
     return visibleStrips;
 }
 
+
+    // /**
+    //  * @param {Palette} palette - Palette to query.
+    //  * @returns {Palette}
+    //  */
+    // #getPaletteInRegularOrNative(palette) {
+    //     const displayNative = this.#getElement(commands.displayNativeColours)?.checked ?? false;
+    //     if (displayNative) {
+    //         return PaletteUtil.clonePaletteWithNativeColours(palette, { preserveIds: true });
+    //     } else {
+    //         return palette;
+    //     }
+    // }
+
 function displaySelectedProject() {
     if (getProject()) {
         if (getPaletteList().length === 0) {

--- a/wwwroot/modules/models/project.js
+++ b/wwwroot/modules/models/project.js
@@ -25,7 +25,7 @@ export default class Project {
         this.#title = value;
     }
 
-    /** Gets or sets the system type (either 'smsgg' or 'gb'). */
+    /** Gets or sets the system type (either 'smsgg', 'gb' or 'nes'). */
     get systemType() {
         return this.#systemType;
     }

--- a/wwwroot/modules/ui/paletteEditor.js
+++ b/wwwroot/modules/ui/paletteEditor.js
@@ -6,8 +6,6 @@ import EventDispatcher from "../components/eventDispatcher.js";
 import PaletteList from "../models/paletteList.js";
 import PaletteEditorContextMenu from "./paletteEditorContextMenu.js";
 import TemplateUtil from "../util/templateUtil.js";
-import PaletteFactory from "../factory/paletteFactory.js";
-import PaletteUtil from "../util/paletteUtil.js";
 import StackedListReorderHelper from "../engine/helpers/stackedListReorderHelper.js";
 
 
@@ -58,10 +56,6 @@ export default class PaletteEditor extends ComponentBase {
     #selectedPaletteId = null;
     /** @type {HTMLButtonElement[]} */
     #paletteButtons = [];
-    /** @type {HTMLTableCellElement[]} */
-    #paletteCells = [];
-    /** @type {HTMLElement} */
-    #uiPaletteList;
     /** @type {HTMLElement} */
     #uiItemProperties;
     /** @type {HTMLInputElement} */
@@ -117,7 +111,6 @@ export default class PaletteEditor extends ComponentBase {
             }
         });
 
-        this.#uiPaletteList = this.#element.querySelector('[data-smsgfx-id=palette-list]');
         this.#uiItemProperties = this.#element.querySelector('[data-smsgfx-id=palette-properties]');
 
         this.#btnPaletteTitle = this.#element.querySelector('[data-smsgfx-id=editPaletteTitle]');
@@ -535,8 +528,7 @@ export default class PaletteEditor extends ComponentBase {
      */
     #createPaletteColourIndexButtons(palette) {
 
-        const renderPalette = this.#getPaletteInRegularOrNative(palette);
-        const data = renderPalette.getColours().map((colour, index) => {
+        const data = palette.getColours().map((colour, index) => {
             return {
                 colourIndex: index,
                 hex: ColourUtil.toHex(colour.r, colour.g, colour.b),
@@ -582,11 +574,10 @@ export default class PaletteEditor extends ComponentBase {
      * @param {Palette} palette
      */
     #updatePaletteColourIndexButtonColour(palette) {
-        const renderPalette = this.#getPaletteInRegularOrNative(palette);
         const element = this.#element.querySelector('[data-smsgfx-id=palette-colours]');
         element.querySelectorAll('button[data-colour-index]').forEach((/** @type {HTMLButtonElement} */ button) => {
             const colourIndex = parseInt(button.getAttribute('data-colour-index'));
-            const paletteColour = renderPalette.getColour(colourIndex);
+            const paletteColour = palette.getColour(colourIndex);
             const colourHex = ColourUtil.toHex(paletteColour.r, paletteColour.g, paletteColour.b);
             button.setAttribute('data-colour-hex', colourHex);
             button.style.backgroundColor = colourHex
@@ -624,19 +615,6 @@ export default class PaletteEditor extends ComponentBase {
                 button.classList.add('highlighted');
             }
         });
-    }
-
-    /**
-     * @param {Palette} palette - Palette to query.
-     * @returns {Palette}
-     */
-    #getPaletteInRegularOrNative(palette) {
-        const displayNative = this.#getElement(commands.displayNativeColours)?.checked ?? false;
-        if (displayNative) {
-            return PaletteUtil.clonePaletteWithNativeColours(palette, { preserveIds: true });
-        } else {
-            return palette;
-        }
     }
 
 

--- a/wwwroot/modules/ui/tileEditor.js
+++ b/wwwroot/modules/ui/tileEditor.js
@@ -76,8 +76,6 @@ export default class TileEditor extends ComponentBase {
     #tileEditorContextMenu;
     /** @type {PaletteList} */
     #paletteList = null;
-    /** @type {PaletteList} */
-    #renderPaletteList = null;
     /** @type {TileGridProvider} */
     #tileGrid = null;
     /** @type {TileSet} */
@@ -92,9 +90,12 @@ export default class TileEditor extends ComponentBase {
     #canvasMouseLeftDown = false;
     #canvasMouseMiddleDown = false;
     #canvasMouseRightDown = false;
-    #displayNative = true;
     #dispatcher;
     #enabled = true;
+    #pixelGridColour = '#98a200';
+    #pixelGridOpacity = 0.5;
+    #tileGridColour = '#98a200';
+    #tileGridOpacity = 1;
 
     /** @type {Worker?} */
     #viewportWorker = null;
@@ -171,31 +172,26 @@ export default class TileEditor extends ComponentBase {
             paletteUpdated = true;
         }
 
-        // Native display
-        if (typeof state?.displayNative === 'boolean') {
-            this.#displayNative = state.displayNative;
-            if (state.displayNative && this.#paletteList?.getPalettes().filter((p) => p.system === 'gb').length > 0) {
-                message.pixelGridColour = '#98a200';
-                message.pixelGridOpacity = 0.5;
-                message.tileGridColour = '#98a200';
-                message.tileGridOpacity = 1;
-            } else {
-                message.pixelGridColour = '#000000';
-                message.pixelGridOpacity = 0.2;
-                message.tileGridColour = '#000000';
-                message.tileGridOpacity = 0.4;
-            }
-            paletteUpdated = true;
+        if (typeof state?.pixelGridColour === 'string' && state?.pixelGridColour.length > 0) {
+            this.#pixelGridColour = state?.pixelGridColour;
+            message.pixelGridColour = this.#pixelGridColour;
+        }
+        if (typeof state?.pixelGridOpacity === 'number') {
+            this.#pixelGridOpacity = state?.pixelGridOpacity;
+            message.pixelGridOpacity = this.#pixelGridOpacity;
+        }
+        if (typeof state?.tileGridColour === 'string' && state?.tileGridColour.length > 0) {
+            this.#tileGridColour = state?.tileGridColour;
+            message.tileGridColour = this.#tileGridColour;
+        }
+        if (typeof state?.tileGridOpacity === 'number') {
+            this.#tileGridOpacity = state?.tileGridOpacity;
+            message.tileGridOpacity = this.#tileGridOpacity;
         }
 
-        // Update native palette if either palette or native option was updated
+        // Update palette 
         if (paletteUpdated && this.#paletteList) {
-            if (this.#displayNative) {
-                this.#renderPaletteList = PaletteUtil.clonePaletteListWithNativeColours(this.#paletteList, { preserveIds: true });
-            } else {
-                this.#renderPaletteList = this.#paletteList;
-            }
-            message.paletteList = PaletteListJsonSerialiser.toSerialisable(this.#renderPaletteList);
+            message.paletteList = PaletteListJsonSerialiser.toSerialisable(this.#paletteList);
             message.redrawFull = true;
         }
 
@@ -819,7 +815,6 @@ export default class TileEditor extends ComponentBase {
  * @property {number?} scale - Current scale level.
  * @property {boolean?} [scaleRelativeToMouse] - Scale based on the mouse cursor position?.
  * @property {number?} [tilesPerBlock] - The amount of tiles per tile block.
- * @property {boolean?} displayNative - Should the tile editor display native colours?
  * @property {number?} selectedTileIndex - Currently selected tile index.
  * @property {number?} cursorSize - Size of the cursor in px.
  * @property {string?} cursor - Cursor to use when the mouse hovers over the image editor.
@@ -832,6 +827,10 @@ export default class TileEditor extends ComponentBase {
  * @property {number?} [lockedPaletteSlotIndex] - When not null, the palette slot index specified here will be repeated from palette 0 across all palettes.
  * @property {boolean?} showTileGrid - Should the tile grid be drawn?
  * @property {boolean?} showPixelGrid - Should the pixel grid be drawn?
+ * @property {string} [pixelGridColour] - Colour of the pixel grid.
+ * @property {number} [pixelGridOpacity] - Opacity of the pixel grid.
+ * @property {string} [tileGridColour] - Colour of the tile grid.
+ * @property {number} [tileGridOpacity] - Opacity of the tile grid.
  * @property {boolean?} enabled - Is the control enabled or disabled?
  * @property {number?} focusedTile - Will ensure that this tile is shown on the screen.
  * @property {number[]?} [updatedTileGridIndexes] - Array of tile grid indexes that were updated.

--- a/wwwroot/modules/ui/tileManager.js
+++ b/wwwroot/modules/ui/tileManager.js
@@ -73,8 +73,6 @@ export default class TileManager extends ComponentBase {
     #dispatcher;
     /** @type {Palette} */
     #palette = null;
-    /** @type {Palette} */
-    #renderPalette = null;
     /** @type {TileMapList} */
     #tileMapList = null;
     /** @type {TileSet} */
@@ -199,7 +197,6 @@ export default class TileManager extends ComponentBase {
         let tileListDirty = false;
         let paletteSlotsDirty = false;
         let paletteDirty = false;
-        let updateRenderPalette = false;
         let updatedTileIds = null;
 
         if (state?.tileMapList && state.tileMapList instanceof TileMapList) {
@@ -252,20 +249,10 @@ export default class TileManager extends ComponentBase {
 
         if (state?.paletteList instanceof PaletteList) {
             this.#paletteList = state.paletteList;
-            updateRenderPalette = true;
             paletteSlotsDirty = true;
         } else if (state?.paletteList === null) {
             this.#paletteList = null;
-            updateRenderPalette = true;
             paletteSlotsDirty = true;
-        }
-
-        if (paletteDirty) {
-            if (this.#palette) {
-                this.#renderPalette = this.#palette;
-            } else {
-                this.#renderPalette = null;
-            }
         }
 
         if (tileMapListingDirty) {
@@ -281,7 +268,7 @@ export default class TileManager extends ComponentBase {
         if (tileMapListingDirty && paletteDirty) {
             this.#tileListing.setState({
                 tileSet: this.#tileSet ?? undefined,
-                palette: this.#renderPalette ?? undefined
+                palette: this.#palette ?? undefined
             });
         } else if (tileMapListingDirty) {
             this.#tileListing.setState({
@@ -289,14 +276,14 @@ export default class TileManager extends ComponentBase {
             });
         } else if (paletteDirty) {
             this.#tileListing.setState({
-                palette: this.#renderPalette ?? undefined
+                palette: this.#palette ?? undefined
             });
         }
 
         if (updatedTileIds) {
             this.#tileListing.setState({
                 updatedTileIds: updatedTileIds,
-                palette: paletteDirty ? this.#renderPalette ?? undefined : undefined
+                palette: paletteDirty ? this.#palette ?? undefined : undefined
             });
         }
 

--- a/wwwroot/modules/ui/tileManager.js
+++ b/wwwroot/modules/ui/tileManager.js
@@ -109,10 +109,6 @@ export default class TileManager extends ComponentBase {
     #selectedTileMapId = null;
     /** @type {PaletteList?} */
     #paletteList = null;
-    /** @type {PaletteList?} */
-    #renderPaletteList = null;
-    /** @type {boolean} */
-    #displayNative = false;
     /** @type {StackedListReorderHelper} */
     #reorderHelper;
 
@@ -264,26 +260,8 @@ export default class TileManager extends ComponentBase {
             paletteSlotsDirty = true;
         }
 
-        if (typeof state?.displayNative === 'boolean' || state?.displayNative === null) {
-            updateRenderPalette = true;
-            this.#displayNative = state?.displayNative ?? false;
-            paletteSlotsDirty = true;
-        }
-
-        if (updateRenderPalette) {
-            if (this.#paletteList && this.#displayNative) {
-                this.#renderPaletteList = PaletteUtil.clonePaletteListWithNativeColours(this.#paletteList, { preserveIds: true });
-            } else if (this.#paletteList && !this.#displayNative) {
-                this.#renderPaletteList = this.#paletteList;
-            } else {
-                this.#renderPaletteList = null;
-            }
-        }
-
         if (paletteDirty) {
-            if (this.#palette && this.#displayNative) {
-                this.#renderPalette = PaletteUtil.clonePaletteWithNativeColours(this.#palette, { preserveId: true });
-            } else if (this.#palette && !this.#displayNative) {
+            if (this.#palette) {
                 this.#renderPalette = this.#palette;
             } else {
                 this.#renderPalette = null;
@@ -298,10 +276,6 @@ export default class TileManager extends ComponentBase {
             });
             this.#reorderHelper.wireUpItems();
             this.#showPropertiesPanelInList();
-        }
-
-        if (paletteDirty) {
-
         }
 
         if (tileMapListingDirty && paletteDirty) {
@@ -473,7 +447,7 @@ export default class TileManager extends ComponentBase {
 
 
     #populatePaletteSelectors() {
-        const paletteList = this.#renderPaletteList;
+        const paletteList = this.#paletteList;
         const numberOfPaletteSlots = this.#numberOfPaletteSlots;
         const tileMap = this.#tileMapList?.getTileMapById(this.#selectedTileMapId);
 
@@ -513,9 +487,9 @@ export default class TileManager extends ComponentBase {
     }
 
     #populatePaletteColours() {
-        if (!this.#tileMapList || !this.#renderPaletteList) return;
+        if (!this.#tileMapList || !this.#paletteList) return;
 
-        const paletteList = this.#renderPaletteList;
+        const paletteList = this.#paletteList;
         const tileMap = this.#tileMapList.getTileMapById(this.#selectedTileMapId);
 
         if (!tileMap) return;
@@ -633,7 +607,6 @@ export default class TileManager extends ComponentBase {
  * @property {TileSet?} [tileSet] - Tile set to be displayed.
  * @property {Palette?} [palette] - Palette to use to render the tiles.
  * @property {PaletteList?} [paletteList] - Available palettes for the palette slots.
- * @property {boolean?} [displayNative] - Should the palettes be displayed in native colours?
  * @property {string?} [selectedTileMapId] - Unique ID of the selected tile map.
  * @property {string?} [selectedTileId] - Unique ID of the selected tile.
  * @property {string[]?} [updatedTileIds] - Array of unique tile IDs that were updated.


### PR DESCRIPTION
#236
UI components are no longer aware of the "Display Native" colour concept, native colours are now managed in main file and propagated to components.